### PR TITLE
Do not instanciate all possible Requirements Tables on activation.

### DIFF
--- a/designs/requirement/plugins/org.obeonetwork.dsl.requirement.design/description/requirement.odesign
+++ b/designs/requirement/plugins/org.obeonetwork.dsl.requirement.design/description/requirement.odesign
@@ -6,7 +6,7 @@
     <details key="SVG.BundledImageDescription.BorderColor" value=""/>
   </eAnnotations>
   <ownedViewpoints name="Requirements">
-    <ownedRepresentations xsi:type="description_1:EditionTableDescription" name="Requirements Table" titleExpression="&lt;%table%> Requirements Table" initialisation="true" domainClass="requirement.Repository">
+    <ownedRepresentations xsi:type="description_1:EditionTableDescription" name="Requirements Table" titleExpression="&lt;%table%> Requirements Table" domainClass="requirement.Repository">
       <ownedLineMappings name="REQ_Repository" domainClass="requirement.Repository" semanticCandidatesExpression="&lt;%self%>" headerLabelExpression="&lt;%name%>">
         <ownedSubLines name="REQ_Category" reusedSubLines="//@ownedViewpoints[name='Requirements']/@ownedRepresentations[name='Requirements%20Table']/@ownedLineMappings[name='REQ_Repository']/@ownedSubLines[name='REQ_Category']" reusedInMappings="//@ownedViewpoints[name='Requirements']/@ownedRepresentations[name='Requirements%20Table']/@ownedLineMappings[name='REQ_Repository']/@ownedSubLines[name='REQ_Category']" domainClass="requirement.Category" semanticCandidatesExpression="&lt;%eContents()%>" headerLabelExpression="&lt;%id%> - &lt;%name%>">
           <ownedSubLines name="REQ_Requirement" domainClass="requirement.Requirement" semanticCandidatesExpression="&lt;%requirements%>" headerLabelExpression="&lt;%id%> - &lt;%name%>">


### PR DESCRIPTION
Setting the initialisation flag to true forces a complete walk over
all the semantic elements in the session as soon as the parent
Viewpoint is enabled. This can be very bad for performance on large
models.
