### PR TITLE
Adding generators for XSD and WSDL contracts from SOA DSL

### DIFF
--- a/generators/soa/features/org.obeonetwork.dsl.soa.gen.contracts.feature/.project
+++ b/generators/soa/features/org.obeonetwork.dsl.soa.gen.contracts.feature/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.obeonetwork.dsl.soa.gen.contracts.feature</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.FeatureBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.FeatureNature</nature>
+	</natures>
+</projectDescription>

--- a/generators/soa/features/org.obeonetwork.dsl.soa.gen.contracts.feature/build.properties
+++ b/generators/soa/features/org.obeonetwork.dsl.soa.gen.contracts.feature/build.properties
@@ -1,0 +1,2 @@
+bin.includes = feature.xml,\
+               feature.properties

--- a/generators/soa/features/org.obeonetwork.dsl.soa.gen.contracts.feature/epl-v10.html
+++ b/generators/soa/features/org.obeonetwork.dsl.soa.gen.contracts.feature/epl-v10.html
@@ -1,0 +1,262 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
+<title>Eclipse Public License - Version 1.0</title>
+<style type="text/css">
+  body {
+    size: 8.5in 11.0in;
+    margin: 0.25in 0.5in 0.25in 0.5in;
+    tab-interval: 0.5in;
+    }
+  p {  	
+    margin-left: auto;
+    margin-top:  0.5em;
+    margin-bottom: 0.5em;
+    }
+  p.list {
+  	margin-left: 0.5in;
+    margin-top:  0.05em;
+    margin-bottom: 0.05em;
+    }
+  </style>
+
+</head>
+
+<body lang="EN-US">
+
+<h2>Eclipse Public License - v 1.0</h2>
+
+<p>THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+PUBLIC LICENSE (&quot;AGREEMENT&quot;). ANY USE, REPRODUCTION OR
+DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS
+AGREEMENT.</p>
+
+<p><b>1. DEFINITIONS</b></p>
+
+<p>&quot;Contribution&quot; means:</p>
+
+<p class="list">a) in the case of the initial Contributor, the initial
+code and documentation distributed under this Agreement, and</p>
+<p class="list">b) in the case of each subsequent Contributor:</p>
+
+<p class="list">i) changes to the Program, and</p>
+<p class="list">ii) additions to the Program;</p>
+<p class="list">where such changes and/or additions to the Program
+originate from and are distributed by that particular Contributor. A
+Contribution 'originates' from a Contributor if it was added to the
+Program by such Contributor itself or anyone acting on such
+Contributor's behalf. Contributions do not include additions to the
+Program which: (i) are separate modules of software distributed in
+conjunction with the Program under their own license agreement, and (ii)
+are not derivative works of the Program.</p>
+
+<p>&quot;Contributor&quot; means any person or entity that distributes
+the Program.</p>
+
+<p>&quot;Licensed Patents&quot; mean patent claims licensable by a
+Contributor which are necessarily infringed by the use or sale of its
+Contribution alone or when combined with the Program.</p>
+
+<p>&quot;Program&quot; means the Contributions distributed in accordance
+with this Agreement.</p>
+
+<p>&quot;Recipient&quot; means anyone who receives the Program under
+this Agreement, including all Contributors.</p>
+
+<p><b>2. GRANT OF RIGHTS</b></p>
+
+<p class="list">a) Subject to the terms of this Agreement, each
+Contributor hereby grants Recipient a non-exclusive, worldwide,
+royalty-free copyright license to reproduce, prepare derivative works
+of, publicly display, publicly perform, distribute and sublicense the
+Contribution of such Contributor, if any, and such derivative works, in
+source code and object code form.</p>
+
+<p class="list">b) Subject to the terms of this Agreement, each
+Contributor hereby grants Recipient a non-exclusive, worldwide,
+royalty-free patent license under Licensed Patents to make, use, sell,
+offer to sell, import and otherwise transfer the Contribution of such
+Contributor, if any, in source code and object code form. This patent
+license shall apply to the combination of the Contribution and the
+Program if, at the time the Contribution is added by the Contributor,
+such addition of the Contribution causes such combination to be covered
+by the Licensed Patents. The patent license shall not apply to any other
+combinations which include the Contribution. No hardware per se is
+licensed hereunder.</p>
+
+<p class="list">c) Recipient understands that although each Contributor
+grants the licenses to its Contributions set forth herein, no assurances
+are provided by any Contributor that the Program does not infringe the
+patent or other intellectual property rights of any other entity. Each
+Contributor disclaims any liability to Recipient for claims brought by
+any other entity based on infringement of intellectual property rights
+or otherwise. As a condition to exercising the rights and licenses
+granted hereunder, each Recipient hereby assumes sole responsibility to
+secure any other intellectual property rights needed, if any. For
+example, if a third party patent license is required to allow Recipient
+to distribute the Program, it is Recipient's responsibility to acquire
+that license before distributing the Program.</p>
+
+<p class="list">d) Each Contributor represents that to its knowledge it
+has sufficient copyright rights in its Contribution, if any, to grant
+the copyright license set forth in this Agreement.</p>
+
+<p><b>3. REQUIREMENTS</b></p>
+
+<p>A Contributor may choose to distribute the Program in object code
+form under its own license agreement, provided that:</p>
+
+<p class="list">a) it complies with the terms and conditions of this
+Agreement; and</p>
+
+<p class="list">b) its license agreement:</p>
+
+<p class="list">i) effectively disclaims on behalf of all Contributors
+all warranties and conditions, express and implied, including warranties
+or conditions of title and non-infringement, and implied warranties or
+conditions of merchantability and fitness for a particular purpose;</p>
+
+<p class="list">ii) effectively excludes on behalf of all Contributors
+all liability for damages, including direct, indirect, special,
+incidental and consequential damages, such as lost profits;</p>
+
+<p class="list">iii) states that any provisions which differ from this
+Agreement are offered by that Contributor alone and not by any other
+party; and</p>
+
+<p class="list">iv) states that source code for the Program is available
+from such Contributor, and informs licensees how to obtain it in a
+reasonable manner on or through a medium customarily used for software
+exchange.</p>
+
+<p>When the Program is made available in source code form:</p>
+
+<p class="list">a) it must be made available under this Agreement; and</p>
+
+<p class="list">b) a copy of this Agreement must be included with each
+copy of the Program.</p>
+
+<p>Contributors may not remove or alter any copyright notices contained
+within the Program.</p>
+
+<p>Each Contributor must identify itself as the originator of its
+Contribution, if any, in a manner that reasonably allows subsequent
+Recipients to identify the originator of the Contribution.</p>
+
+<p><b>4. COMMERCIAL DISTRIBUTION</b></p>
+
+<p>Commercial distributors of software may accept certain
+responsibilities with respect to end users, business partners and the
+like. While this license is intended to facilitate the commercial use of
+the Program, the Contributor who includes the Program in a commercial
+product offering should do so in a manner which does not create
+potential liability for other Contributors. Therefore, if a Contributor
+includes the Program in a commercial product offering, such Contributor
+(&quot;Commercial Contributor&quot;) hereby agrees to defend and
+indemnify every other Contributor (&quot;Indemnified Contributor&quot;)
+against any losses, damages and costs (collectively &quot;Losses&quot;)
+arising from claims, lawsuits and other legal actions brought by a third
+party against the Indemnified Contributor to the extent caused by the
+acts or omissions of such Commercial Contributor in connection with its
+distribution of the Program in a commercial product offering. The
+obligations in this section do not apply to any claims or Losses
+relating to any actual or alleged intellectual property infringement. In
+order to qualify, an Indemnified Contributor must: a) promptly notify
+the Commercial Contributor in writing of such claim, and b) allow the
+Commercial Contributor to control, and cooperate with the Commercial
+Contributor in, the defense and any related settlement negotiations. The
+Indemnified Contributor may participate in any such claim at its own
+expense.</p>
+
+<p>For example, a Contributor might include the Program in a commercial
+product offering, Product X. That Contributor is then a Commercial
+Contributor. If that Commercial Contributor then makes performance
+claims, or offers warranties related to Product X, those performance
+claims and warranties are such Commercial Contributor's responsibility
+alone. Under this section, the Commercial Contributor would have to
+defend claims against the other Contributors related to those
+performance claims and warranties, and if a court requires any other
+Contributor to pay any damages as a result, the Commercial Contributor
+must pay those damages.</p>
+
+<p><b>5. NO WARRANTY</b></p>
+
+<p>EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS
+PROVIDED ON AN &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS
+OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION,
+ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY
+OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely
+responsible for determining the appropriateness of using and
+distributing the Program and assumes all risks associated with its
+exercise of rights under this Agreement , including but not limited to
+the risks and costs of program errors, compliance with applicable laws,
+damage to or loss of data, programs or equipment, and unavailability or
+interruption of operations.</p>
+
+<p><b>6. DISCLAIMER OF LIABILITY</b></p>
+
+<p>EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT
+NOR ANY CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING
+WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OR
+DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED
+HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.</p>
+
+<p><b>7. GENERAL</b></p>
+
+<p>If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of
+the remainder of the terms of this Agreement, and without further action
+by the parties hereto, such provision shall be reformed to the minimum
+extent necessary to make such provision valid and enforceable.</p>
+
+<p>If Recipient institutes patent litigation against any entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that the
+Program itself (excluding combinations of the Program with other
+software or hardware) infringes such Recipient's patent(s), then such
+Recipient's rights granted under Section 2(b) shall terminate as of the
+date such litigation is filed.</p>
+
+<p>All Recipient's rights under this Agreement shall terminate if it
+fails to comply with any of the material terms or conditions of this
+Agreement and does not cure such failure in a reasonable period of time
+after becoming aware of such noncompliance. If all Recipient's rights
+under this Agreement terminate, Recipient agrees to cease use and
+distribution of the Program as soon as reasonably practicable. However,
+Recipient's obligations under this Agreement and any licenses granted by
+Recipient relating to the Program shall continue and survive.</p>
+
+<p>Everyone is permitted to copy and distribute copies of this
+Agreement, but in order to avoid inconsistency the Agreement is
+copyrighted and may only be modified in the following manner. The
+Agreement Steward reserves the right to publish new versions (including
+revisions) of this Agreement from time to time. No one other than the
+Agreement Steward has the right to modify this Agreement. The Eclipse
+Foundation is the initial Agreement Steward. The Eclipse Foundation may
+assign the responsibility to serve as the Agreement Steward to a
+suitable separate entity. Each new version of the Agreement will be
+given a distinguishing version number. The Program (including
+Contributions) may always be distributed subject to the version of the
+Agreement under which it was received. In addition, after a new version
+of the Agreement is published, Contributor may elect to distribute the
+Program (including its Contributions) under the new version. Except as
+expressly stated in Sections 2(a) and 2(b) above, Recipient receives no
+rights or licenses to the intellectual property of any Contributor under
+this Agreement, whether expressly, by implication, estoppel or
+otherwise. All rights in the Program not expressly granted under this
+Agreement are reserved.</p>
+
+<p>This Agreement is governed by the laws of the State of New York and
+the intellectual property laws of the United States of America. No party
+to this Agreement will bring a legal action under this Agreement more
+than one year after the cause of action arose. Each party waives its
+rights to a jury trial in any resulting litigation.</p>
+
+</body>
+
+</html>

--- a/generators/soa/features/org.obeonetwork.dsl.soa.gen.contracts.feature/feature.properties
+++ b/generators/soa/features/org.obeonetwork.dsl.soa.gen.contracts.feature/feature.properties
@@ -1,0 +1,12 @@
+#################################################################################
+# Copyright (c) 2013 Obeo.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+# 
+# Contributors:
+#     Laurent Broudoux (@lbroudoux) - initial API and implementation
+#################################################################################
+providerName = Laurent Broudoux
+featureName = SOA Contracts Generator

--- a/generators/soa/features/org.obeonetwork.dsl.soa.gen.contracts.feature/feature.xml
+++ b/generators/soa/features/org.obeonetwork.dsl.soa.gen.contracts.feature/feature.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="org.obeonetwork.dsl.soa.gen.contracts.feature"
+      label="Acceleo SOA Contracts Module Feature"
+      version="2.3.0.qualifier"
+      provider-name="%providerName">
+
+   <description url="http://www.example.com/description">
+      [Enter Feature Description here.]
+   </description>
+
+   <copyright url="http://www.example.com/copyright">
+      [Enter Copyright Description here.]
+   </copyright>
+
+   <license url="http://www.example.com/license">
+      [Enter License Description here.]
+   </license>
+
+   <plugin
+         id="org.obeonetwork.dsl.soa.gen.contracts"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+</feature>

--- a/generators/soa/features/org.obeonetwork.dsl.soa.gen.contracts.feature/pom.xml
+++ b/generators/soa/features/org.obeonetwork.dsl.soa.gen.contracts.feature/pom.xml
@@ -1,0 +1,14 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.obeonetwork</groupId>
+    <artifactId>generators.parent</artifactId>
+    <version>2.3.0-SNAPSHOT</version>
+    <relativePath>../../../../releng/org.obeonetwork.informationsystem.parent/generators/pom.xml</relativePath>
+  </parent>
+  <groupId>org.obeonetwork</groupId>
+  <artifactId>org.obeonetwork.dsl.soa.gen.contracts.feature</artifactId>
+  <version>2.3.0-SNAPSHOT</version>
+  <packaging>eclipse-feature</packaging>
+  <name>SOA Contracts Generator from SOA Model feature</name>
+</project>

--- a/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/.classpath
+++ b/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" output="bin" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/.project
+++ b/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/.project
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.obeonetwork.dsl.soa.gen.contracts</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.acceleo.ide.ui.acceleoBuilder</name>
+			<arguments>
+				<dictionary>
+					<key>compilation.kind</key>
+					<value>compilation.absolute.path</value>
+				</dictionary>
+				<dictionary>
+					<key>compliance</key>
+					<value>pragmatic</value>
+				</dictionary>
+				<dictionary>
+					<key>resource.kind</key>
+					<value>xmi</value>
+				</dictionary>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.acceleo.ide.ui.acceleoNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+	</natures>
+</projectDescription>

--- a/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/META-INF/MANIFEST.MF
+++ b/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/META-INF/MANIFEST.MF
@@ -1,0 +1,28 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Acceleo SOA Contracts Module Plug-in
+Bundle-SymbolicName: org.obeonetwork.dsl.soa.gen.contracts
+Bundle-Version: 2.3.0.qualifier
+Bundle-Activator: org.obeonetwork.dsl.soa.gen.contracts.Activator
+Bundle-Vendor: %providerName
+Require-Bundle: org.eclipse.core.runtime,
+ org.eclipse.emf.ecore,
+ org.eclipse.emf.ecore,
+ org.eclipse.emf.ecore.xmi,
+ org.eclipse.ocl,
+ org.eclipse.ocl.ecore,
+ org.eclipse.acceleo.common;bundle-version="3.2.1",
+ org.eclipse.acceleo.parser;bundle-version="3.2.1";resolution:=optional,
+ org.eclipse.acceleo.model;bundle-version="3.2.1",
+ org.eclipse.acceleo.profiler;bundle-version="3.2.1",
+ org.eclipse.acceleo.engine;bundle-version="3.2.1",
+ com.google.guava;bundle-version="10.0.1",
+ org.obeonetwork.dsl.soa,
+ org.obeonetwork.dsl.overview,
+ org.obeonetwork.dsl.entity
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-ActivationPolicy: lazy
+Eclipse-LazyStart: true
+Export-Package: org.obeonetwork.dsl.soa.gen.contracts.main,
+ org.obeonetwork.dsl.soa.gen.contracts.services
+

--- a/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/build.acceleo
+++ b/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/build.acceleo
@@ -1,0 +1,26 @@
+<!-- ===================================================================== -->
+<!-- Custom targets.                                                       -->
+<!-- Set customBuildCallbacks = build.acceleo in your build.properties.    -->
+<!-- ===================================================================== -->
+<project name="Build Acceleo Module" default="noDefault">    
+    <!-- ================================================================= -->
+    <!-- Default target                                                    -->
+    <!-- ================================================================= -->
+    <target name="noDefault">
+        <echo message="This file must be called with explicit targets" />
+    </target>
+
+    <!-- ================================================================= -->
+    <!-- This will be called automatically after the compilation of each   -->
+    <!-- Bundle... in dependency order.                                    -->
+    <!-- ================================================================= -->
+    <target name="post.compile.@dot">
+        <acceleoCompiler 
+            sourceFolder="${target.folder}"
+            outputFolder="${target.folder}"
+            dependencies=""
+            binaryResource="false"
+            packagesToRegister="">
+        </acceleoCompiler>
+    </target>    
+</project>

--- a/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/build.properties
+++ b/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/build.properties
@@ -1,0 +1,6 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .
+customBuildCallbacks = build.acceleo
+jre.compilation.profile = JavaSE-1.6

--- a/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/plugin.properties
+++ b/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/plugin.properties
@@ -1,0 +1,12 @@
+#################################################################################
+# Copyright (c) 2013 Obeo.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+# 
+# Contributors:
+#     Laurent Broudoux (@lbroudoux) - initial API and implementation
+#################################################################################
+providerName = Laurent Broudoux
+pluginName = SOA Contracts Generator

--- a/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/pom.xml
+++ b/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/pom.xml
@@ -1,0 +1,50 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.obeonetwork</groupId>
+    <artifactId>generators.parent</artifactId>
+    <version>2.3.0-SNAPSHOT</version>
+    <relativePath>../../../../releng/org.obeonetwork.informationsystem.parent/generators/pom.xml</relativePath>
+  </parent>
+  <groupId>org.obeonetwork</groupId>
+  <artifactId>org.obeonetwork.dsl.soa.gen.contracts</artifactId>
+  <version>2.3.0-SNAPSHOT</version>
+  <packaging>eclipse-plugin</packaging>
+  <name>SOA Contracts Generator from SOA Model</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.acceleo</groupId>
+        <artifactId>maven</artifactId>
+        <version>3.2.1</version>
+        <executions>
+          <execution>
+            <phase>compile</phase>
+            <goals>
+              <goal>acceleo-compile</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <useBinaryResources>false</useBinaryResources>
+          <usePlatformResourcePath>true</usePlatformResourcePath>
+          <acceleoProject>
+            <root>${project.basedir}</root>
+            <entries>
+              <entry>
+                <input>src</input>
+                <output>target/classes</output>
+              </entry>
+            </entries>
+          </acceleoProject>
+          <packagesToRegister>
+            <packageToRegister>org.eclipse.emf.ecore.EcorePackage</packageToRegister>
+            <packageToRegister>org.obeonetwork.dsl.environment.EnvironmentPackage</packageToRegister>
+          </packagesToRegister>
+          <uriHandler>org.eclipse.acceleo.maven.AcceleoURIHandler</uriHandler>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/src/org/obeonetwork/dsl/soa/gen/contracts/Activator.java
+++ b/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/src/org/obeonetwork/dsl/soa/gen/contracts/Activator.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2008, 2011 Obeo.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.obeonetwork.dsl.soa.gen.contracts;
+
+import org.eclipse.core.runtime.Plugin;
+import org.osgi.framework.BundleContext;
+
+/**
+ * The activator class controls the plug-in life cycle.
+ */
+public class Activator extends Plugin {
+
+    /**
+     * The plug-in ID.
+     */
+    public static final String PLUGIN_ID = "org.obeonetwork.dsl.soa.gen.contracts";
+
+    /**
+     * The shared instance.
+     */
+    private static Activator plugin;
+    
+    /**
+     * The constructor.
+     */
+    public Activator() {
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.eclipse.core.runtime.Plugin#start(org.osgi.framework.BundleContext)
+     */
+    public void start(BundleContext context) throws Exception {
+        super.start(context);
+        plugin = this;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.eclipse.core.runtime.Plugin#stop(org.osgi.framework.BundleContext)
+     */
+    public void stop(BundleContext context) throws Exception {
+        plugin = null;
+        super.stop(context);
+    }
+
+    /**
+     * Returns the shared instance.
+     *
+     * @return the shared instance
+     */
+    public static Activator getDefault() {
+        return plugin;
+    }
+
+}

--- a/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/src/org/obeonetwork/dsl/soa/gen/contracts/common/attributes.mtl
+++ b/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/src/org/obeonetwork/dsl/soa/gen/contracts/common/attributes.mtl
@@ -1,0 +1,27 @@
+[comment encoding = UTF-8 /]
+[module attributes('http://www.obeonetwork.org/dsl/environment/2.0.0')]
+
+[import org::obeonetwork::dsl::soa::gen::contracts::common::common /]
+[import org::obeonetwork::dsl::soa::gen::contracts::common::types /]
+[import org::obeonetwork::dsl::soa::gen::contracts::services::constraintsServices /]
+
+
+[template public genXsdElement(anAttribute : Attribute) post(trim())]
+[if (hasStringConstraint(anAttribute))]
+<xs:element name="[anAttribute.name/]" [anAttribute.multiplicity.genMultiplicity()/]>
+  [genStringRestriction(getStringConstraintMinLength(anAttribute), getStringConstraintMaxLength(anAttribute), 'xs')/]
+</xs:element>
+[elseif (hasIntegerConstraint(anAttribute))]
+<xs:element name="[anAttribute.name/]" [anAttribute.multiplicity.genMultiplicity()/]>
+  [genIntegerRestriction(getIntegerConstraintMinValue(anAttribute), getIntegerConstraintMaxValue(anAttribute), 'xs')/]
+</xs:element>
+[else]
+<xs:element name="[anAttribute.name/]" type="[genXsdTypeName(anAttribute.type, 'xs')/]" [anAttribute.multiplicity.genMultiplicity()/]>[anAttribute.genXsdObjectDocumentation('xs')/]</xs:element>
+[/if]
+[/template]
+
+[query protected hasStringConstraint(anAttribute : Attribute) : Boolean =
+   not anAttribute.metadatas.oclIsUndefined() and anAttribute.metadatas.oclAsType(MetaDataContainer).metadatas.oclAsType(Annotation).title->includes('@Size') /]
+
+[query protected hasIntegerConstraint(anAttribute : Attribute) : Boolean =
+   not anAttribute.metadatas.oclIsUndefined() and anAttribute.metadatas.oclAsType(MetaDataContainer).metadatas.oclAsType(Annotation).title->includes('@Value') /]

--- a/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/src/org/obeonetwork/dsl/soa/gen/contracts/common/common.mtl
+++ b/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/src/org/obeonetwork/dsl/soa/gen/contracts/common/common.mtl
@@ -1,0 +1,23 @@
+[comment encoding = UTF-8 /]
+[module common('http://www.obeonetwork.org/dsl/environment/2.0.0')]
+
+
+[template public genXsdObjectDocumentation(obj : ObeoDSMObject, xsPrefix : String) post (trim())]
+[if (not obj.description.oclIsUndefined())]
+<[xsPrefix/]:annotation>
+  <[xsPrefix/]:documentation>
+    [obj.description/]
+  </[xsPrefix/]:documentation>
+</[xsPrefix/]:annotation>
+[/if]
+[/template]
+
+[template public genMultiplicity(multiplicity : MultiplicityKind) post (trim())]
+[if (multiplicity = MultiplicityKind::ZERO_ONE)]
+minOccurs="0"
+[elseif (multiplicity = MultiplicityKind::ONE_STAR)]
+maxOccurs="unbounded"
+[elseif (multiplicity = MultiplicityKind::ZERO_STAR)]
+minOccurs="0" maxOccurs="unbounded"
+[/if]
+[/template]

--- a/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/src/org/obeonetwork/dsl/soa/gen/contracts/common/entities.mtl
+++ b/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/src/org/obeonetwork/dsl/soa/gen/contracts/common/entities.mtl
@@ -1,0 +1,63 @@
+[comment encoding = UTF-8 /]
+[module entities('http://www.obeonetwork.org/dsl/entity/2.0.0', 'http://www.obeonetwork.org/dsl/environment/2.0.0')]
+
+[import org::obeonetwork::dsl::soa::gen::contracts::common::common /]
+[import org::obeonetwork::dsl::soa::gen::contracts::common::types /]
+[import org::obeonetwork::dsl::soa::gen::contracts::services::constraintsServices /]
+
+
+[template public genXsdElement(anOclAny : OclAny) post (trim())]
+[if (anOclAny.oclIsKindOf(Attribute))]
+
+[let att : Attribute = anOclAny.oclAsType(Attribute)]
+[if ((att.multiplicity = MultiplicityKind::ZERO_ONE) or (att.multiplicity = MultiplicityKind::ONE))]
+[if (hasStringConstraint(att))]
+<xs:element name="[att.name/]" [att.multiplicity.genMultiplicity()/]>
+  [att.genXsdObjectDocumentation('xs')/]
+  [genStringRestriction(getStringConstraintMinLength(att), getStringConstraintMaxLength(att), 'xs')/]
+</xs:element>
+[elseif (hasIntegerConstraint(att))]
+<xs:element name="[att.name/]" [att.multiplicity.genMultiplicity()/]>
+  [att.genXsdObjectDocumentation('xs')/]
+  [genIntegerRestriction(getIntegerConstraintMinValue(att), getIntegerConstraintMaxValue(att), 'xs')/]
+</xs:element>
+[else]
+<xs:element name="[att.name/]" type="[genXsdTypeName(att.type, 'xs')/]" [att.multiplicity.genMultiplicity()/]>
+  [att.genXsdObjectDocumentation('xs')/]
+</xs:element>  
+[/if]
+
+[else]
+<xs:element name="[att.name/]s">
+  [att.genXsdObjectDocumentation('xs')/]
+  [att.genWrappingXsdComplexType()/]
+</xs:element>
+[/if]
+
+[/let]
+[/if]
+[/template]
+
+[query protected hasStringConstraint(anAttribute : Attribute) : Boolean =
+   not anAttribute.metadatas.oclIsUndefined() and anAttribute.metadatas.oclAsType(MetaDataContainer).metadatas.oclAsType(Annotation).title->includes('@Size') /]
+
+[query protected hasIntegerConstraint(anAttribute : Attribute) : Boolean =
+   not anAttribute.metadatas.oclIsUndefined() and anAttribute.metadatas.oclAsType(MetaDataContainer).metadatas.oclAsType(Annotation).title->includes('@Value') /]
+
+[template private genWrappingXsdComplexType(att : Attribute) post (trim())]
+<xs:complexType>
+  <xs:sequence>
+    [if (hasStringConstraint(att))]
+    <xs:element name="[att.name/]" [att.multiplicity.genMultiplicity()/]>
+      [genStringRestriction(getStringConstraintMinLength(att), getStringConstraintMaxLength(att), 'xs')/]
+    </xs:element>
+    [elseif (hasIntegerConstraint(att))]
+    <xs:element name="[att.name/]" [att.multiplicity.genMultiplicity()/]>
+      [genIntegerRestriction(getIntegerConstraintMinValue(att), getIntegerConstraintMaxValue(att), 'xs')/]
+    </xs:element>
+    [else]
+    <xs:element name="[att.name/]" type="[genXsdTypeName(att.type, 'xs')/]" [att.multiplicity.genMultiplicity()/]/>
+    [/if]
+  </xs:sequence>
+</xs:complexType>
+[/template]

--- a/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/src/org/obeonetwork/dsl/soa/gen/contracts/common/references.mtl
+++ b/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/src/org/obeonetwork/dsl/soa/gen/contracts/common/references.mtl
@@ -1,0 +1,25 @@
+[comment encoding = UTF-8 /]
+[module references('http://www.obeonetwork.org/dsl/environment/2.0.0', 'http://www.obeonetwork.org/dsl/soa/2.0.0')]
+
+[import org::obeonetwork::dsl::soa::gen::contracts::common::common /]
+[import org::obeonetwork::dsl::soa::gen::contracts::common::types /]
+
+
+[template public genXsdElement(aReference : Reference) post (trim())]
+[if ((aReference.multiplicity = MultiplicityKind::ZERO_ONE) or (aReference.multiplicity = MultiplicityKind::ONE))]
+<xs:element name="[aReference.name/]" type="[genXsdTypeName(aReference.type, aReference.eContainer(Category), 'xs', 'tns')/]" [aReference.multiplicity.genMultiplicity()/]>[aReference.genXsdObjectDocumentation('xs')/]</xs:element>
+[else]
+<xs:element name="[aReference.name/]s">
+  [aReference.genXsdObjectDocumentation('xs')/]
+  [aReference.genWrappingXsdComplexType()/]
+</xs:element>
+[/if]
+[/template]
+
+[template private genWrappingXsdComplexType(aReference : Reference) post (trim())]
+<xs:complexType>
+  <xs:sequence>
+    <xs:element name="[aReference.name/]" type="[genXsdTypeName(aReference.type, aReference.eContainer(Category), 'xs', 'tns')/]" [aReference.multiplicity.genMultiplicity()/]/>
+  </xs:sequence>
+</xs:complexType>
+[/template]

--- a/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/src/org/obeonetwork/dsl/soa/gen/contracts/common/types.mtl
+++ b/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/src/org/obeonetwork/dsl/soa/gen/contracts/common/types.mtl
@@ -1,0 +1,67 @@
+[comment encoding = UTF-8 /]
+[module types('http://www.obeonetwork.org/dsl/environment/2.0.0', 'http://www.obeonetwork.org/dsl/soa/2.0.0')]
+
+[import org::obeonetwork::dsl::soa::gen::contracts::services::namespaceServices/]
+
+
+[template public genXsdTypeName(aType : Type, xsdPrefix : String) post (trim())]
+[if (aType.isPrimitiveType())]
+[xsdPrefix/]:[aType.convertPrimitiveToXsdType()/]
+[elseif (not aType.eContainer(Category).oclIsUndefined())]
+[let aCategory : Category = aType.eContainer(Category).oclAsType(Category)]
+[aCategory.getNamespacePrefix()/]:[aType.name/]
+[/let]
+[/if]
+[/template]
+
+[template public genXsdTypeName(aType : Type, ctxCategory : Category, xsdPrefix : String, tnsPrefix : String) post (trim())]
+[if (aType.isPrimitiveType())]
+[xsdPrefix/]:[aType.convertPrimitiveToXsdType()/]
+[elseif (not aType.eContainer(Category).oclIsUndefined())]
+   [let aCategory : Category = aType.eContainer(Category).oclAsType(Category)]
+      [if (aCategory <> ctxCategory)]
+[aCategory.getNamespacePrefix()/]:[aType.name/]
+      [else]
+[tnsPrefix/]:[aType.name/]
+      [/if]
+   [/let]
+[/if]
+[/template]
+
+[query public isPrimitiveType(aType : Type) : Boolean = aType.oclIsTypeOf(PrimitiveType) /]
+
+[template public convertPrimitiveToXsdType(aType : Type) post (trim())]
+[if (aType.name = 'String')]
+string
+[elseif (aType.name = 'Integer')]
+int
+[elseif (aType.name = 'Long')]
+long
+[elseif (aType.name = 'Date')]
+dateTime
+[elseif (aType.name = 'Float')]
+float
+[elseif (aType.name = 'Double')]
+double
+[elseif (aType.name = 'Boolean')]
+boolean
+[/if]
+[/template]
+
+[template public genStringRestriction(minLength : Integer, maxLength : Integer, xsdPrefix : String) post (trim())]
+<[xsdPrefix/]:simpleType>
+  <[xsdPrefix/]:restriction base="[xsdPrefix/]:string">
+    [if (minLength <> -1)]<[xsdPrefix/]:minLength value="[minLength/]"></[xsdPrefix/]:minLength>[/if]
+    [if (maxLength <> -1)]<[xsdPrefix/]:maxLength value="[maxLength/]"></[xsdPrefix/]:maxLength>[/if]
+  </[xsdPrefix/]:restriction>
+</[xsdPrefix/]:simpleType>
+[/template]
+
+[template public genIntegerRestriction(minInclusive : Integer, maxInclusive : Integer, xsdPrefix : String) post (trim())]
+<[xsdPrefix/]:simpleType>
+  <[xsdPrefix/]:restriction base="xs:int">
+    [if (minInclusive <> -1)]<[xsdPrefix/]:minInclusive value="[minInclusive/]"></[xsdPrefix/]:minInclusive>[/if]
+    [if (maxInclusive <> -1)]<[xsdPrefix/]:maxInclusive value="[maxInclusive/]"></[xsdPrefix/]:maxInclusive>[/if]
+  </[xsdPrefix/]:restriction>
+</[xsdPrefix/]:simpleType>
+[/template]

--- a/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/src/org/obeonetwork/dsl/soa/gen/contracts/files/wsdlFile.mtl
+++ b/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/src/org/obeonetwork/dsl/soa/gen/contracts/files/wsdlFile.mtl
@@ -1,0 +1,162 @@
+[comment encoding = UTF-8 /]
+[module wsdlFile('http://www.obeonetwork.org/dsl/environment/2.0.0', 'http://www.obeonetwork.org/dsl/soa/2.0.0')]
+
+[import org::obeonetwork::dsl::soa::gen::contracts::common::common /]
+[import org::obeonetwork::dsl::soa::gen::contracts::common::types /]
+[import org::obeonetwork::dsl::soa::gen::contracts::files::xsdFile /]
+[import org::obeonetwork::dsl::soa::gen::contracts::services::namespaceServices /]
+
+
+[template public genFullPathFile(aService : Service) post (trim())]
+[if (aService.version.oclIsUndefined())]
+   [aService.name.concat('.wsdl')/]
+[else]
+   [aService.name.concat('-v').concat(aService.version.toString()).concat('.wsdl')/]
+[/if]
+[/template]
+
+[template public genWsdlFileBody(aService : Service)]
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" name="[aService.name/]"
+        xmlns:tns="[aService.getTargetNamespace()/]" targetNamespace="[aService.getTargetNamespace()/]">
+  [aService.genWSDLTypes()/]
+  [aService.genWSDLMessages()/]
+  [aService.genWSDLBinding()/]
+  [aService.genWSDLPortType()/]
+  [aService.genWSDLService()/]
+</wsdl:definitions>
+[/template]
+
+[template protected genWSDLTypes(aService : Service)]
+<wsdl:types>
+  <xsd:schema targetNamespace="[aService.getTargetNamespace()/]"
+    [for (aCategory : Category | aService.getAllDTOCategories())]
+      xmlns:[aCategory.getNamespacePrefix()/]="[aCategory.getTargetNamespace()/]"
+    [/for]
+  >
+  [for (aCategory : Category | aService.getAllDTOCategories())]
+    <xsd:import schemaLocation="[aCategory.genFullPathFile()/]" namespace="[aCategory.getTargetNamespace()/]"></xsd:import>
+  [/for]
+  [for (anOperation : Operation | aService.ownedInterface.ownedOperations)]
+    <xsd:element name="[anOperation.name/]">
+      <xsd:complexType>
+        <xsd:sequence>
+        [for (input : Parameter | anOperation.input)]
+          <xsd:element name="[input.name/]" type="[input.type.genXsdTypeName('xsd')/]"
+            minOccurs="[input.lower/]" maxOccurs="[input.upper/]"/>
+        [/for]
+        </xsd:sequence>
+      </xsd:complexType>
+    </xsd:element>
+    [if (anOperation.kind = OperationKind::REQUEST_RESPONSE)]
+    <xsd:element name="[anOperation.name/]Response">
+      <xsd:complexType>
+        <xsd:sequence>
+        [for (output : Parameter | anOperation.output)]
+          <xsd:element name="[output.name/]" type="[output.type.genXsdTypeName('xsd')/]"
+            minOccurs="[output.lower/]" maxOccurs="[output.upper/]"/>
+        [/for]
+        </xsd:sequence>
+      </xsd:complexType>
+    </xsd:element>
+    [if (anOperation.fault->size() <> 0)]
+    [for (aParam : Parameter | anOperation.fault)]
+    <xsd:element name="[anOperation.name/][aParam.name/]" type="[aParam.type.genXsdTypeName('xsd')/]"/>
+    [/for]
+    [/if]
+    [/if]
+  [/for]
+  </xsd:schema>
+</wsdl:types>
+[/template]
+
+[template protected genWSDLMessages(aService : Service)]
+
+[for (anOperation : Operation | aService.ownedInterface.ownedOperations)]
+<wsdl:message name="[anOperation.name/]Request">
+  <wsdl:part element="tns:[anOperation.name/]" name="parameters"/>
+</wsdl:message>
+[if (anOperation.kind = OperationKind::REQUEST_RESPONSE)]
+<wsdl:message name="[anOperation.name/]Response">
+  <wsdl:part element="tns:[anOperation.name/]Response" name="parameters"/>
+</wsdl:message>
+[if (anOperation.fault->size() <> 0)]
+[for (aParam : Parameter | anOperation.fault)]
+<wsdl:message name="[anOperation.name/][aParam.name/]">
+  <wsdl:part element="tns:[anOperation.name/][aParam.name/]" name="parameters"/> 
+</wsdl:message>
+[/for]
+[/if]
+[/if]
+[/for]
+[/template]
+
+[template protected genWSDLBinding(aService : Service)]
+<wsdl:binding name="[aService.name/]SOAP" type="tns:[aService.name/]">
+  <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+  [for (anOperation : Operation | aService.ownedInterface.ownedOperations)]
+  <wsdl:operation name="[anOperation.name/]">
+    <soap:operation soapAction="[aService.getTargetNamespace()/]/[anOperation.name/]"/>
+    <wsdl:input>
+      <soap:body use="literal"/>
+    </wsdl:input>
+    [if (anOperation.kind = OperationKind::REQUEST_RESPONSE)]
+    <wsdl:output>
+      <soap:body use="literal"/>
+    </wsdl:output>
+    [if (anOperation.fault->size() <> 0)]
+    [for (aParam : Parameter | anOperation.fault)]
+    <wsdl:fault name="[aParam.name/]"></wsdl:fault>
+    [/for]
+    [/if]
+    [/if]
+  </wsdl:operation>
+  [/for]
+</wsdl:binding>
+[/template]
+
+[template protected genWSDLPortType(aService : Service)]
+<wsdl:portType name="[aService.name/]">
+  [for (anOperation : Operation | aService.ownedInterface.ownedOperations)]
+  <wsdl:operation name="[anOperation.name/]">
+    <wsdl:input message="tns:[anOperation.name/]Request"/>
+    [if (anOperation.kind = OperationKind::REQUEST_RESPONSE)]
+    <wsdl:output message="tns:[anOperation.name/]Response"/>
+    [if (anOperation.fault->size() <> 0)]
+    [for (aParam : Parameter | anOperation.fault)]
+    <wsdl:fault name="[aParam.name/]" message="tns:[anOperation.name/][aParam.name/]"/>
+    [/for]
+    [/if]
+    [/if]
+  </wsdl:operation>
+  [/for]
+</wsdl:portType>
+[/template]
+
+[template protected genWSDLService(aService : Service)]
+<wsdl:service name="[aService.name/]">
+  <wsdl:port binding="tns:[aService.name/]SOAP" name="[aService.name/]Port">
+    <soap:address location="http://www.example.org/"/>
+  </wsdl:port>
+</wsdl:service>
+[/template]
+
+
+[query protected getAllDTOCategories(aService : Service) : Sequence(Category) =
+        Sequence(Category){}
+                ->merge(aService.ownedInterface.ownedOperations.input.type->filter(DTO).eContainer(Category))
+        ->merge(aService.ownedInterface.ownedOperations.output.type->filter(DTO).eContainer(Category))
+                ->asOrderedSet()->asSequence()
+/]
+
+[query private merge(firstSequence : Sequence(T), secondSequence : Sequence(T)) : Sequence(Type) =
+     if not (firstSequence->size() = 0) then
+         firstSequence->union(secondSequence)
+     else if not (secondSequence->size() = 0) then
+            secondSequence
+         else
+             Sequence(Type){}
+         endif
+     endif
+/]

--- a/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/src/org/obeonetwork/dsl/soa/gen/contracts/files/xsdFile.mtl
+++ b/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/src/org/obeonetwork/dsl/soa/gen/contracts/files/xsdFile.mtl
@@ -1,0 +1,80 @@
+[comment encoding = UTF-8 /]
+[module xsdFile('http://www.obeonetwork.org/dsl/soa/2.0.0', 'http://www.obeonetwork.org/dsl/environment/2.0.0', 'http://www.obeonetwork.org/dsl/entity/2.0.0')]
+
+[import org::obeonetwork::dsl::soa::gen::contracts::common::common /]
+[import org::obeonetwork::dsl::soa::gen::contracts::common::attributes /]
+[import org::obeonetwork::dsl::soa::gen::contracts::common::entities /]
+[import org::obeonetwork::dsl::soa::gen::contracts::common::references /]
+[import org::obeonetwork::dsl::soa::gen::contracts::common::types /]
+[import org::obeonetwork::dsl::soa::gen::contracts::services::namespaceServices /]
+
+
+[template public genFullPathFile(aCategory : Category) post (trim())]
+[let system : System = aCategory.eContainer(System).oclAsType(System)]
+[if (system.version.oclIsUndefined())]
+   [system.name.concat(aCategory.name).concat('.xsd')/]
+[else]
+   [system.name.concat('-').concat(aCategory.name).concat('-v').concat(system.version.toString()).concat('.xsd')/]
+[/if]
+[/let]
+[/template]
+
+[template public genXsdFileBody(aCategory : Category)]
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="[aCategory.getTargetNamespace()/]" xmlns:tns="[aCategory.getTargetNamespace()/]"
+[for (aCategory : Category | aCategory.getReferencedDTOCategories())]
+    xmlns:[aCategory.getNamespacePrefix()/]="[aCategory.getTargetNamespace()/]"
+[/for]>
+[for (aCategory : Category | aCategory.getReferencedDTOCategories())]
+  <xs:import schemaLocation="[aCategory.genFullPathFile()/]" namespace="[aCategory.getTargetNamespace()/]"></xs:import>
+[/for]
+  [aCategory.genXsdObjectDocumentation('xs')/]
+  [aCategory.genXsdTypes()/]
+</xs:schema>
+[/template]
+
+[template public genXsdTypes(aCategory : Category) post (trim())]
+[for (aType : Type | aCategory.types)]
+  <xs:complexType name="[aType.name/]">
+    [aType.genXsdObjectDocumentation('xs')/][aType.genXsdTypeContent()/]
+  </xs:complexType>
+[/for]
+[/template]
+
+[template public genXsdTypeContent(aType : Type) post (trim())]
+[if (aType.oclIsKindOf(DTO))]
+[if (not aType.oclAsType(DTO).supertype.oclIsUndefined())]
+<xs:complexContent>
+  <xs:extension base="[genXsdTypeName(aType.oclAsType(DTO).supertype, aType.eContainer(Category), 'xs', 'tns')/]">
+    [aType.genXsdElementsSequence()/]
+  </xs:extension>
+</xs:complexContent>
+[else]
+[aType.genXsdElementsSequence()/]
+[/if]
+[/if]
+[/template]
+
+[template public genXsdElementsSequence(aType : Type) post (trim())]
+<xs:sequence>
+[for (att : ObeoDSMObject | aType.oclAsType(DTO).getAllAttributes())]
+  [att.genXsdElement()/]
+[/for]
+[for (ref : Reference | aType.oclAsType(DTO).references)]
+  [ref.genXsdElement()/]
+[/for]
+</xs:sequence>
+[/template]
+
+[query protected getAllAttributes(aDto : DTO) : Sequence(Attribute) =
+        aDto.ownedAttributes->asSequence()
+                ->union(aDto.associatedTypes.oclAsType(Entity).ownedAttributes->asSequence()) /]
+
+[query protected getReferencedDTOCategories(aCategory : Category) : Sequence(Category) =
+        aCategory.eAllContents(DTO).references.type.eContainer(Category)->select(c|c <> aCategory)
+                ->union(aCategory.getDTOSupertypes().eContainer(Category)->select(c|c <> aCategory))
+/]
+
+[query protected getDTOSupertypes(aCategory : Category) : Sequence(Type) =
+        Sequence(Type){}->union(aCategory.eAllContents(DTO).supertype->select(t|not t.oclIsUndefined()))
+/]

--- a/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/src/org/obeonetwork/dsl/soa/gen/contracts/main/DtoXsd.java
+++ b/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/src/org/obeonetwork/dsl/soa/gen/contracts/main/DtoXsd.java
@@ -1,0 +1,412 @@
+/*******************************************************************************
+ * Copyright (c) 2008, 2012 Obeo.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.obeonetwork.dsl.soa.gen.contracts.main;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.acceleo.engine.event.IAcceleoTextGenerationListener;
+import org.eclipse.acceleo.engine.generation.strategy.IAcceleoGenerationStrategy;
+import org.eclipse.acceleo.engine.service.AbstractAcceleoGenerator;
+import org.eclipse.emf.common.util.BasicMonitor;
+import org.eclipse.emf.common.util.Monitor;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+
+/**
+ * Entry point of the 'DtoXsd' generation module.
+ *
+ * @generated
+ */
+public class DtoXsd extends AbstractAcceleoGenerator {
+    /**
+     * The name of the module.
+     *
+     * @generated
+     */
+    public static final String MODULE_FILE_NAME = "/org/obeonetwork/dsl/soa/gen/contracts/main/dtoXsd";
+    
+    /**
+     * The name of the templates that are to be generated.
+     *
+     * @generated
+     */
+    public static final String[] TEMPLATE_NAMES = { "dtoXsd" };
+    
+    /**
+     * The list of properties files from the launch parameters (Launch configuration).
+     *
+     * @generated
+     */
+    private List<String> propertiesFiles = new ArrayList<String>();
+
+    /**
+     * Allows the public constructor to be used. Note that a generator created
+     * this way cannot be used to launch generations before one of
+     * {@link #initialize(EObject, File, List)} or
+     * {@link #initialize(URI, File, List)} is called.
+     * <p>
+     * The main reason for this constructor is to allow clients of this
+     * generation to call it from another Java file, as it allows for the
+     * retrieval of {@link #getProperties()} and
+     * {@link #getGenerationListeners()}.
+     * </p>
+     *
+     * @generated
+     */
+    public DtoXsd() {
+        // Empty implementation
+    }
+
+    /**
+     * This allows clients to instantiates a generator with all required information.
+     * 
+     * @param modelURI
+     *            URI where the model on which this generator will be used is located.
+     * @param targetFolder
+     *            This will be used as the output folder for this generation : it will be the base path
+     *            against which all file block URLs will be resolved.
+     * @param arguments
+     *            If the template which will be called requires more than one argument taken from the model,
+     *            pass them here.
+     * @throws IOException
+     *             This can be thrown in three scenarios : the module cannot be found, it cannot be loaded, or
+     *             the model cannot be loaded.
+     * @generated
+     */
+    public DtoXsd(URI modelURI, File targetFolder,
+            List<? extends Object> arguments) throws IOException {
+        initialize(modelURI, targetFolder, arguments);
+    }
+
+    /**
+     * This allows clients to instantiates a generator with all required information.
+     * 
+     * @param model
+     *            We'll iterate over the content of this element to find Objects matching the first parameter
+     *            of the template we need to call.
+     * @param targetFolder
+     *            This will be used as the output folder for this generation : it will be the base path
+     *            against which all file block URLs will be resolved.
+     * @param arguments
+     *            If the template which will be called requires more than one argument taken from the model,
+     *            pass them here.
+     * @throws IOException
+     *             This can be thrown in two scenarios : the module cannot be found, or it cannot be loaded.
+     * @generated
+     */
+    public DtoXsd(EObject model, File targetFolder,
+            List<? extends Object> arguments) throws IOException {
+        initialize(model, targetFolder, arguments);
+    }
+    
+    /**
+     * This can be used to launch the generation from a standalone application.
+     * 
+     * @param args
+     *            Arguments of the generation.
+     * @generated
+     */
+    public static void main(String[] args) {
+        try {
+            if (args.length < 2) {
+                System.out.println("Arguments not valid : {model, folder}.");
+            } else {
+                URI modelURI = URI.createFileURI(args[0]);
+                File folder = new File(args[1]);
+                
+                List<String> arguments = new ArrayList<String>();
+                
+                /*
+                 * If you want to change the content of this method, do NOT forget to change the "@generated"
+                 * tag in the Javadoc of this method to "@generated NOT". Without this new tag, any compilation
+                 * of the Acceleo module with the main template that has caused the creation of this class will
+                 * revert your modifications.
+                 */
+
+                /*
+                 * Add in this list all the arguments used by the starting point of the generation
+                 * If your main template is called on an element of your model and a String, you can
+                 * add in "arguments" this "String" attribute.
+                 */
+                
+                DtoXsd generator = new DtoXsd(modelURI, folder, arguments);
+                
+                /*
+                 * Add the properties from the launch arguments.
+                 * If you want to programmatically add new properties, add them in "propertiesFiles"
+                 * You can add the absolute path of a properties files, or even a project relative path.
+                 * If you want to add another "protocol" for your properties files, please override 
+                 * "getPropertiesLoaderService(AcceleoService)" in order to return a new property loader.
+                 * The behavior of the properties loader service is explained in the Acceleo documentation
+                 * (Help -> Help Contents).
+                 */
+                 
+                for (int i = 2; i < args.length; i++) {
+                    generator.addPropertiesFile(args[i]);
+                }
+                
+                generator.doGenerate(new BasicMonitor());
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Launches the generation described by this instance.
+     * 
+     * @param monitor
+     *            This will be used to display progress information to the user.
+     * @throws IOException
+     *             This will be thrown if any of the output files cannot be saved to disk.
+     * @generated
+     */
+    @Override
+    public void doGenerate(Monitor monitor) throws IOException {
+        /*
+         * TODO if you wish to change the generation as a whole, override this. The default behavior should
+         * be sufficient in most cases. If you want to change the content of this method, do NOT forget to
+         * change the "@generated" tag in the Javadoc of this method to "@generated NOT". Without this new tag,
+         * any compilation of the Acceleo module with the main template that has caused the creation of this
+         * class will revert your modifications. If you encounter a problem with an unresolved proxy during the
+         * generation, you can remove the comments in the following instructions to check for problems. Please
+         * note that those instructions may have a significant impact on the performances.
+         */
+
+        //org.eclipse.emf.ecore.util.EcoreUtil.resolveAll(model);
+
+        /*
+         * If you want to check for potential errors in your models before the launch of the generation, you
+         * use the code below.
+         */
+
+        //if (model != null && model.eResource() != null) {
+        //    List<org.eclipse.emf.ecore.resource.Resource.Diagnostic> errors = model.eResource().getErrors();
+        //    for (org.eclipse.emf.ecore.resource.Resource.Diagnostic diagnostic : errors) {
+        //        System.err.println(diagnostic.toString());
+        //    }
+        //}
+
+        super.doGenerate(monitor);
+    }
+    
+    /**
+     * If this generator needs to listen to text generation events, listeners can be returned from here.
+     * 
+     * @return List of listeners that are to be notified when text is generated through this launch.
+     * @generated
+     */
+    @Override
+    public List<IAcceleoTextGenerationListener> getGenerationListeners() {
+        List<IAcceleoTextGenerationListener> listeners = super.getGenerationListeners();
+        /*
+         * TODO if you need to listen to generation event, add listeners to the list here. If you want to change
+         * the content of this method, do NOT forget to change the "@generated" tag in the Javadoc of this method
+         * to "@generated NOT". Without this new tag, any compilation of the Acceleo module with the main template
+         * that has caused the creation of this class will revert your modifications.
+         */
+        return listeners;
+    }
+    
+    /**
+     * If you need to change the way files are generated, this is your entry point.
+     * <p>
+     * The default is {@link org.eclipse.acceleo.engine.generation.strategy.DefaultStrategy}; it generates
+     * files on the fly. If you only need to preview the results, return a new
+     * {@link org.eclipse.acceleo.engine.generation.strategy.PreviewStrategy}. Both of these aren't aware of
+     * the running Eclipse and can be used standalone.
+     * </p>
+     * <p>
+     * If you need the file generation to be aware of the workspace (A typical example is when you wanna
+     * override files that are under clear case or any other VCS that could forbid the overriding), then
+     * return a new {@link org.eclipse.acceleo.engine.generation.strategy.WorkspaceAwareStrategy}.
+     * <b>Note</b>, however, that this <b>cannot</b> be used standalone.
+     * </p>
+     * <p>
+     * All three of these default strategies support merging through JMerge.
+     * </p>
+     * 
+     * @return The generation strategy that is to be used for generations launched through this launcher.
+     * @generated
+     */
+    @Override
+    public IAcceleoGenerationStrategy getGenerationStrategy() {
+        return super.getGenerationStrategy();
+    }
+    
+    /**
+     * This will be called in order to find and load the module that will be launched through this launcher.
+     * We expect this name not to contain file extension, and the module to be located beside the launcher.
+     * 
+     * @return The name of the module that is to be launched.
+     * @generated
+     */
+    @Override
+    public String getModuleName() {
+        return MODULE_FILE_NAME;
+    }
+    
+    /**
+     * If the module(s) called by this launcher require properties files, return their qualified path from
+     * here.Take note that the first added properties files will take precedence over subsequent ones if they
+     * contain conflicting keys.
+     * 
+     * @return The list of properties file we need to add to the generation context.
+     * @see java.util.ResourceBundle#getBundle(String)
+     * @generated
+     */
+    @Override
+    public List<String> getProperties() {
+        /*
+         * If you want to change the content of this method, do NOT forget to change the "@generated"
+         * tag in the Javadoc of this method to "@generated NOT". Without this new tag, any compilation
+         * of the Acceleo module with the main template that has caused the creation of this class will
+         * revert your modifications.
+         */
+
+        /*
+         * TODO if your generation module requires access to properties files, add their qualified path to the list here.
+         * 
+         * Properties files can be located in an Eclipse plug-in or in the file system (all Acceleo projects are Eclipse
+         * plug-in). In order to use properties files located in an Eclipse plugin, you need to add the path of the properties
+         * files to the "propertiesFiles" list:
+         * 
+         * final String prefix = "platform:/plugin/";
+         * final String pluginName = "org.eclipse.acceleo.module.sample";
+         * final String packagePath = "/org/eclipse/acceleo/module/sample/properties/";
+         * final String fileName = "default.properties";
+         * propertiesFiles.add(prefix + pluginName + packagePath + fileName);
+         * 
+         * With this mechanism, you can load properties files from your plugin or from another plugin.
+         * 
+         * You may want to load properties files from the file system, for that you need to add the absolute path of the file:
+         * 
+         * propertiesFiles.add("C:\Users\MyName\MyFile.properties");
+         * 
+         * If you want to let your users add properties files located in the same folder as the model:
+         *
+         * if (EMFPlugin.IS_ECLIPSE_RUNNING && model != null && model.eResource() != null) { 
+         *     propertiesFiles.addAll(AcceleoEngineUtils.getPropertiesFilesNearModel(model.eResource()));
+         * }
+         * 
+         * To learn more about Properties Files, have a look at the Acceleo documentation (Help -> Help Contents).
+         */
+        return propertiesFiles;
+    }
+    
+    /**
+     * Adds a properties file in the list of properties files.
+     * 
+     * @param propertiesFile
+     *            The properties file to add.
+     * @generated
+     * @since 3.1
+     */
+    @Override
+    public void addPropertiesFile(String propertiesFile) {
+        this.propertiesFiles.add(propertiesFile);
+    }
+    
+    /**
+     * This will be used to get the list of templates that are to be launched by this launcher.
+     * 
+     * @return The list of templates to call on the module {@link #getModuleName()}.
+     * @generated
+     */
+    @Override
+    public String[] getTemplateNames() {
+        return TEMPLATE_NAMES;
+    }
+    
+    /**
+     * This can be used to update the resource set's package registry with all needed EPackages.
+     * 
+     * @param resourceSet
+     *            The resource set which registry has to be updated.
+     * @generated
+     */
+    @Override
+    public void registerPackages(ResourceSet resourceSet) {
+        super.registerPackages(resourceSet);
+        if (!isInWorkspace(org.obeonetwork.dsl.overview.OverviewPackage.class)) {
+            resourceSet.getPackageRegistry().put(org.obeonetwork.dsl.overview.OverviewPackage.eINSTANCE.getNsURI(), org.obeonetwork.dsl.overview.OverviewPackage.eINSTANCE);
+        }
+        if (!isInWorkspace(org.obeonetwork.dsl.soa.SoaPackage.class)) {
+            resourceSet.getPackageRegistry().put(org.obeonetwork.dsl.soa.SoaPackage.eINSTANCE.getNsURI(), org.obeonetwork.dsl.soa.SoaPackage.eINSTANCE);
+        }
+        
+        /*
+         * If you want to change the content of this method, do NOT forget to change the "@generated"
+         * tag in the Javadoc of this method to "@generated NOT". Without this new tag, any compilation
+         * of the Acceleo module with the main template that has caused the creation of this class will
+         * revert your modifications.
+         */
+        
+        /*
+         * If you need additional package registrations, you can register them here. The following line
+         * (in comment) is an example of the package registration for UML.
+         * 
+         * You can use the method  "isInWorkspace(Class c)" to check if the package that you are about to
+         * register is in the workspace.
+         * 
+         * To register a package properly, please follow the following conventions:
+         *
+         * If the package is located in another plug-in, already installed in Eclipse. The following content should
+         * have been generated at the beginning of this method. Do not register the package using this mechanism if
+         * the metamodel is located in the workspace.
+         *  
+         * if (!isInWorkspace(UMLPackage.class)) {
+         *     // The normal package registration if your metamodel is in a plugin.
+         *     resourceSet.getPackageRegistry().put(UMLPackage.eNS_URI, UMLPackage.eINSTANCE);
+         * }
+         * 
+         * If the package is located in another project in your workspace, the plugin containing the package has not
+         * been register by EMF and Acceleo should register it automatically. If you want to use the generator in
+         * stand alone, the regular registration (seen a couple lines before) is needed.
+         * 
+         * To learn more about Package Registration, have a look at the Acceleo documentation (Help -> Help Contents).
+         */
+    }
+
+    /**
+     * This can be used to update the resource set's resource factory registry with all needed factories.
+     * 
+     * @param resourceSet
+     *            The resource set which registry has to be updated.
+     * @generated
+     */
+    @Override
+    public void registerResourceFactories(ResourceSet resourceSet) {
+        super.registerResourceFactories(resourceSet);
+        /*
+         * If you want to change the content of this method, do NOT forget to change the "@generated"
+         * tag in the Javadoc of this method to "@generated NOT". Without this new tag, any compilation
+         * of the Acceleo module with the main template that has caused the creation of this class will
+         * revert your modifications.
+         */
+        
+        /*
+         * TODO If you need additional resource factories registrations, you can register them here. the following line
+         * (in comment) is an example of the resource factory registration for UML.
+         *
+         * If you want to use the generator in stand alone, the resource factory registration will be required.
+         *  
+         * To learn more about the registration of Resource Factories, have a look at the Acceleo documentation (Help -> Help Contents). 
+         */ 
+        
+        // resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put(UMLResource.FILE_EXTENSION, UMLResource.Factory.INSTANCE);
+    }
+    
+}

--- a/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/src/org/obeonetwork/dsl/soa/gen/contracts/main/GenerateAll.java
+++ b/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/src/org/obeonetwork/dsl/soa/gen/contracts/main/GenerateAll.java
@@ -1,0 +1,409 @@
+/*******************************************************************************
+ * Copyright (c) 2008, 2012 Obeo.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.obeonetwork.dsl.soa.gen.contracts.main;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.acceleo.engine.event.IAcceleoTextGenerationListener;
+import org.eclipse.acceleo.engine.generation.strategy.IAcceleoGenerationStrategy;
+import org.eclipse.acceleo.engine.service.AbstractAcceleoGenerator;
+import org.eclipse.emf.common.util.BasicMonitor;
+import org.eclipse.emf.common.util.Monitor;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+
+/**
+ * Entry point of the 'GenerateAll' generation module.
+ *
+ * @generated
+ */
+public class GenerateAll extends AbstractAcceleoGenerator {
+    /**
+     * The name of the module.
+     *
+     * @generated
+     */
+    public static final String MODULE_FILE_NAME = "/org/obeonetwork/dsl/soa/gen/contracts/main/generateAll";
+    
+    /**
+     * The name of the templates that are to be generated.
+     *
+     * @generated
+     */
+    public static final String[] TEMPLATE_NAMES = { "generateAll" };
+    
+    /**
+     * The list of properties files from the launch parameters (Launch configuration).
+     *
+     * @generated
+     */
+    private List<String> propertiesFiles = new ArrayList<String>();
+
+    /**
+     * Allows the public constructor to be used. Note that a generator created
+     * this way cannot be used to launch generations before one of
+     * {@link #initialize(EObject, File, List)} or
+     * {@link #initialize(URI, File, List)} is called.
+     * <p>
+     * The main reason for this constructor is to allow clients of this
+     * generation to call it from another Java file, as it allows for the
+     * retrieval of {@link #getProperties()} and
+     * {@link #getGenerationListeners()}.
+     * </p>
+     *
+     * @generated
+     */
+    public GenerateAll() {
+        // Empty implementation
+    }
+
+    /**
+     * This allows clients to instantiates a generator with all required information.
+     * 
+     * @param modelURI
+     *            URI where the model on which this generator will be used is located.
+     * @param targetFolder
+     *            This will be used as the output folder for this generation : it will be the base path
+     *            against which all file block URLs will be resolved.
+     * @param arguments
+     *            If the template which will be called requires more than one argument taken from the model,
+     *            pass them here.
+     * @throws IOException
+     *             This can be thrown in three scenarios : the module cannot be found, it cannot be loaded, or
+     *             the model cannot be loaded.
+     * @generated
+     */
+    public GenerateAll(URI modelURI, File targetFolder,
+            List<? extends Object> arguments) throws IOException {
+        initialize(modelURI, targetFolder, arguments);
+    }
+
+    /**
+     * This allows clients to instantiates a generator with all required information.
+     * 
+     * @param model
+     *            We'll iterate over the content of this element to find Objects matching the first parameter
+     *            of the template we need to call.
+     * @param targetFolder
+     *            This will be used as the output folder for this generation : it will be the base path
+     *            against which all file block URLs will be resolved.
+     * @param arguments
+     *            If the template which will be called requires more than one argument taken from the model,
+     *            pass them here.
+     * @throws IOException
+     *             This can be thrown in two scenarios : the module cannot be found, or it cannot be loaded.
+     * @generated
+     */
+    public GenerateAll(EObject model, File targetFolder,
+            List<? extends Object> arguments) throws IOException {
+        initialize(model, targetFolder, arguments);
+    }
+    
+    /**
+     * This can be used to launch the generation from a standalone application.
+     * 
+     * @param args
+     *            Arguments of the generation.
+     * @generated
+     */
+    public static void main(String[] args) {
+        try {
+            if (args.length < 2) {
+                System.out.println("Arguments not valid : {model, folder}.");
+            } else {
+                URI modelURI = URI.createFileURI(args[0]);
+                File folder = new File(args[1]);
+                
+                List<String> arguments = new ArrayList<String>();
+                
+                /*
+                 * If you want to change the content of this method, do NOT forget to change the "@generated"
+                 * tag in the Javadoc of this method to "@generated NOT". Without this new tag, any compilation
+                 * of the Acceleo module with the main template that has caused the creation of this class will
+                 * revert your modifications.
+                 */
+
+                /*
+                 * Add in this list all the arguments used by the starting point of the generation
+                 * If your main template is called on an element of your model and a String, you can
+                 * add in "arguments" this "String" attribute.
+                 */
+                
+                GenerateAll generator = new GenerateAll(modelURI, folder, arguments);
+                
+                /*
+                 * Add the properties from the launch arguments.
+                 * If you want to programmatically add new properties, add them in "propertiesFiles"
+                 * You can add the absolute path of a properties files, or even a project relative path.
+                 * If you want to add another "protocol" for your properties files, please override 
+                 * "getPropertiesLoaderService(AcceleoService)" in order to return a new property loader.
+                 * The behavior of the properties loader service is explained in the Acceleo documentation
+                 * (Help -> Help Contents).
+                 */
+                 
+                for (int i = 2; i < args.length; i++) {
+                    generator.addPropertiesFile(args[i]);
+                }
+                
+                generator.doGenerate(new BasicMonitor());
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Launches the generation described by this instance.
+     * 
+     * @param monitor
+     *            This will be used to display progress information to the user.
+     * @throws IOException
+     *             This will be thrown if any of the output files cannot be saved to disk.
+     * @generated
+     */
+    @Override
+    public void doGenerate(Monitor monitor) throws IOException {
+        /*
+         * TODO if you wish to change the generation as a whole, override this. The default behavior should
+         * be sufficient in most cases. If you want to change the content of this method, do NOT forget to
+         * change the "@generated" tag in the Javadoc of this method to "@generated NOT". Without this new tag,
+         * any compilation of the Acceleo module with the main template that has caused the creation of this
+         * class will revert your modifications. If you encounter a problem with an unresolved proxy during the
+         * generation, you can remove the comments in the following instructions to check for problems. Please
+         * note that those instructions may have a significant impact on the performances.
+         */
+
+        //org.eclipse.emf.ecore.util.EcoreUtil.resolveAll(model);
+
+        /*
+         * If you want to check for potential errors in your models before the launch of the generation, you
+         * use the code below.
+         */
+
+        //if (model != null && model.eResource() != null) {
+        //    List<org.eclipse.emf.ecore.resource.Resource.Diagnostic> errors = model.eResource().getErrors();
+        //    for (org.eclipse.emf.ecore.resource.Resource.Diagnostic diagnostic : errors) {
+        //        System.err.println(diagnostic.toString());
+        //    }
+        //}
+
+        super.doGenerate(monitor);
+    }
+    
+    /**
+     * If this generator needs to listen to text generation events, listeners can be returned from here.
+     * 
+     * @return List of listeners that are to be notified when text is generated through this launch.
+     * @generated
+     */
+    @Override
+    public List<IAcceleoTextGenerationListener> getGenerationListeners() {
+        List<IAcceleoTextGenerationListener> listeners = super.getGenerationListeners();
+        /*
+         * TODO if you need to listen to generation event, add listeners to the list here. If you want to change
+         * the content of this method, do NOT forget to change the "@generated" tag in the Javadoc of this method
+         * to "@generated NOT". Without this new tag, any compilation of the Acceleo module with the main template
+         * that has caused the creation of this class will revert your modifications.
+         */
+        return listeners;
+    }
+    
+    /**
+     * If you need to change the way files are generated, this is your entry point.
+     * <p>
+     * The default is {@link org.eclipse.acceleo.engine.generation.strategy.DefaultStrategy}; it generates
+     * files on the fly. If you only need to preview the results, return a new
+     * {@link org.eclipse.acceleo.engine.generation.strategy.PreviewStrategy}. Both of these aren't aware of
+     * the running Eclipse and can be used standalone.
+     * </p>
+     * <p>
+     * If you need the file generation to be aware of the workspace (A typical example is when you wanna
+     * override files that are under clear case or any other VCS that could forbid the overriding), then
+     * return a new {@link org.eclipse.acceleo.engine.generation.strategy.WorkspaceAwareStrategy}.
+     * <b>Note</b>, however, that this <b>cannot</b> be used standalone.
+     * </p>
+     * <p>
+     * All three of these default strategies support merging through JMerge.
+     * </p>
+     * 
+     * @return The generation strategy that is to be used for generations launched through this launcher.
+     * @generated
+     */
+    @Override
+    public IAcceleoGenerationStrategy getGenerationStrategy() {
+        return super.getGenerationStrategy();
+    }
+    
+    /**
+     * This will be called in order to find and load the module that will be launched through this launcher.
+     * We expect this name not to contain file extension, and the module to be located beside the launcher.
+     * 
+     * @return The name of the module that is to be launched.
+     * @generated
+     */
+    @Override
+    public String getModuleName() {
+        return MODULE_FILE_NAME;
+    }
+    
+    /**
+     * If the module(s) called by this launcher require properties files, return their qualified path from
+     * here.Take note that the first added properties files will take precedence over subsequent ones if they
+     * contain conflicting keys.
+     * 
+     * @return The list of properties file we need to add to the generation context.
+     * @see java.util.ResourceBundle#getBundle(String)
+     * @generated
+     */
+    @Override
+    public List<String> getProperties() {
+        /*
+         * If you want to change the content of this method, do NOT forget to change the "@generated"
+         * tag in the Javadoc of this method to "@generated NOT". Without this new tag, any compilation
+         * of the Acceleo module with the main template that has caused the creation of this class will
+         * revert your modifications.
+         */
+
+        /*
+         * TODO if your generation module requires access to properties files, add their qualified path to the list here.
+         * 
+         * Properties files can be located in an Eclipse plug-in or in the file system (all Acceleo projects are Eclipse
+         * plug-in). In order to use properties files located in an Eclipse plugin, you need to add the path of the properties
+         * files to the "propertiesFiles" list:
+         * 
+         * final String prefix = "platform:/plugin/";
+         * final String pluginName = "org.eclipse.acceleo.module.sample";
+         * final String packagePath = "/org/eclipse/acceleo/module/sample/properties/";
+         * final String fileName = "default.properties";
+         * propertiesFiles.add(prefix + pluginName + packagePath + fileName);
+         * 
+         * With this mechanism, you can load properties files from your plugin or from another plugin.
+         * 
+         * You may want to load properties files from the file system, for that you need to add the absolute path of the file:
+         * 
+         * propertiesFiles.add("C:\Users\MyName\MyFile.properties");
+         * 
+         * If you want to let your users add properties files located in the same folder as the model:
+         *
+         * if (EMFPlugin.IS_ECLIPSE_RUNNING && model != null && model.eResource() != null) { 
+         *     propertiesFiles.addAll(AcceleoEngineUtils.getPropertiesFilesNearModel(model.eResource()));
+         * }
+         * 
+         * To learn more about Properties Files, have a look at the Acceleo documentation (Help -> Help Contents).
+         */
+        return propertiesFiles;
+    }
+    
+    /**
+     * Adds a properties file in the list of properties files.
+     * 
+     * @param propertiesFile
+     *            The properties file to add.
+     * @generated
+     * @since 3.1
+     */
+    @Override
+    public void addPropertiesFile(String propertiesFile) {
+        this.propertiesFiles.add(propertiesFile);
+    }
+    
+    /**
+     * This will be used to get the list of templates that are to be launched by this launcher.
+     * 
+     * @return The list of templates to call on the module {@link #getModuleName()}.
+     * @generated
+     */
+    @Override
+    public String[] getTemplateNames() {
+        return TEMPLATE_NAMES;
+    }
+    
+    /**
+     * This can be used to update the resource set's package registry with all needed EPackages.
+     * 
+     * @param resourceSet
+     *            The resource set which registry has to be updated.
+     * @generated
+     */
+    @Override
+    public void registerPackages(ResourceSet resourceSet) {
+        super.registerPackages(resourceSet);
+        if (!isInWorkspace(org.obeonetwork.dsl.overview.OverviewPackage.class)) {
+            resourceSet.getPackageRegistry().put(org.obeonetwork.dsl.overview.OverviewPackage.eINSTANCE.getNsURI(), org.obeonetwork.dsl.overview.OverviewPackage.eINSTANCE);
+        }
+        
+        /*
+         * If you want to change the content of this method, do NOT forget to change the "@generated"
+         * tag in the Javadoc of this method to "@generated NOT". Without this new tag, any compilation
+         * of the Acceleo module with the main template that has caused the creation of this class will
+         * revert your modifications.
+         */
+        
+        /*
+         * If you need additional package registrations, you can register them here. The following line
+         * (in comment) is an example of the package registration for UML.
+         * 
+         * You can use the method  "isInWorkspace(Class c)" to check if the package that you are about to
+         * register is in the workspace.
+         * 
+         * To register a package properly, please follow the following conventions:
+         *
+         * If the package is located in another plug-in, already installed in Eclipse. The following content should
+         * have been generated at the beginning of this method. Do not register the package using this mechanism if
+         * the metamodel is located in the workspace.
+         *  
+         * if (!isInWorkspace(UMLPackage.class)) {
+         *     // The normal package registration if your metamodel is in a plugin.
+         *     resourceSet.getPackageRegistry().put(UMLPackage.eNS_URI, UMLPackage.eINSTANCE);
+         * }
+         * 
+         * If the package is located in another project in your workspace, the plugin containing the package has not
+         * been register by EMF and Acceleo should register it automatically. If you want to use the generator in
+         * stand alone, the regular registration (seen a couple lines before) is needed.
+         * 
+         * To learn more about Package Registration, have a look at the Acceleo documentation (Help -> Help Contents).
+         */
+    }
+
+    /**
+     * This can be used to update the resource set's resource factory registry with all needed factories.
+     * 
+     * @param resourceSet
+     *            The resource set which registry has to be updated.
+     * @generated
+     */
+    @Override
+    public void registerResourceFactories(ResourceSet resourceSet) {
+        super.registerResourceFactories(resourceSet);
+        /*
+         * If you want to change the content of this method, do NOT forget to change the "@generated"
+         * tag in the Javadoc of this method to "@generated NOT". Without this new tag, any compilation
+         * of the Acceleo module with the main template that has caused the creation of this class will
+         * revert your modifications.
+         */
+        
+        /*
+         * TODO If you need additional resource factories registrations, you can register them here. the following line
+         * (in comment) is an example of the resource factory registration for UML.
+         *
+         * If you want to use the generator in stand alone, the resource factory registration will be required.
+         *  
+         * To learn more about the registration of Resource Factories, have a look at the Acceleo documentation (Help -> Help Contents). 
+         */ 
+        
+        // resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put(UMLResource.FILE_EXTENSION, UMLResource.Factory.INSTANCE);
+    }
+    
+}

--- a/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/src/org/obeonetwork/dsl/soa/gen/contracts/main/ServiceWsdl.java
+++ b/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/src/org/obeonetwork/dsl/soa/gen/contracts/main/ServiceWsdl.java
@@ -1,0 +1,412 @@
+/*******************************************************************************
+ * Copyright (c) 2008, 2012 Obeo.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.obeonetwork.dsl.soa.gen.contracts.main;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.acceleo.engine.event.IAcceleoTextGenerationListener;
+import org.eclipse.acceleo.engine.generation.strategy.IAcceleoGenerationStrategy;
+import org.eclipse.acceleo.engine.service.AbstractAcceleoGenerator;
+import org.eclipse.emf.common.util.BasicMonitor;
+import org.eclipse.emf.common.util.Monitor;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+
+/**
+ * Entry point of the 'ServiceWsdl' generation module.
+ *
+ * @generated
+ */
+public class ServiceWsdl extends AbstractAcceleoGenerator {
+    /**
+     * The name of the module.
+     *
+     * @generated
+     */
+    public static final String MODULE_FILE_NAME = "/org/obeonetwork/dsl/soa/gen/contracts/main/serviceWsdl";
+    
+    /**
+     * The name of the templates that are to be generated.
+     *
+     * @generated
+     */
+    public static final String[] TEMPLATE_NAMES = { "serviceWsdl" };
+    
+    /**
+     * The list of properties files from the launch parameters (Launch configuration).
+     *
+     * @generated
+     */
+    private List<String> propertiesFiles = new ArrayList<String>();
+
+    /**
+     * Allows the public constructor to be used. Note that a generator created
+     * this way cannot be used to launch generations before one of
+     * {@link #initialize(EObject, File, List)} or
+     * {@link #initialize(URI, File, List)} is called.
+     * <p>
+     * The main reason for this constructor is to allow clients of this
+     * generation to call it from another Java file, as it allows for the
+     * retrieval of {@link #getProperties()} and
+     * {@link #getGenerationListeners()}.
+     * </p>
+     *
+     * @generated
+     */
+    public ServiceWsdl() {
+        // Empty implementation
+    }
+
+    /**
+     * This allows clients to instantiates a generator with all required information.
+     * 
+     * @param modelURI
+     *            URI where the model on which this generator will be used is located.
+     * @param targetFolder
+     *            This will be used as the output folder for this generation : it will be the base path
+     *            against which all file block URLs will be resolved.
+     * @param arguments
+     *            If the template which will be called requires more than one argument taken from the model,
+     *            pass them here.
+     * @throws IOException
+     *             This can be thrown in three scenarios : the module cannot be found, it cannot be loaded, or
+     *             the model cannot be loaded.
+     * @generated
+     */
+    public ServiceWsdl(URI modelURI, File targetFolder,
+            List<? extends Object> arguments) throws IOException {
+        initialize(modelURI, targetFolder, arguments);
+    }
+
+    /**
+     * This allows clients to instantiates a generator with all required information.
+     * 
+     * @param model
+     *            We'll iterate over the content of this element to find Objects matching the first parameter
+     *            of the template we need to call.
+     * @param targetFolder
+     *            This will be used as the output folder for this generation : it will be the base path
+     *            against which all file block URLs will be resolved.
+     * @param arguments
+     *            If the template which will be called requires more than one argument taken from the model,
+     *            pass them here.
+     * @throws IOException
+     *             This can be thrown in two scenarios : the module cannot be found, or it cannot be loaded.
+     * @generated
+     */
+    public ServiceWsdl(EObject model, File targetFolder,
+            List<? extends Object> arguments) throws IOException {
+        initialize(model, targetFolder, arguments);
+    }
+    
+    /**
+     * This can be used to launch the generation from a standalone application.
+     * 
+     * @param args
+     *            Arguments of the generation.
+     * @generated
+     */
+    public static void main(String[] args) {
+        try {
+            if (args.length < 2) {
+                System.out.println("Arguments not valid : {model, folder}.");
+            } else {
+                URI modelURI = URI.createFileURI(args[0]);
+                File folder = new File(args[1]);
+                
+                List<String> arguments = new ArrayList<String>();
+                
+                /*
+                 * If you want to change the content of this method, do NOT forget to change the "@generated"
+                 * tag in the Javadoc of this method to "@generated NOT". Without this new tag, any compilation
+                 * of the Acceleo module with the main template that has caused the creation of this class will
+                 * revert your modifications.
+                 */
+
+                /*
+                 * Add in this list all the arguments used by the starting point of the generation
+                 * If your main template is called on an element of your model and a String, you can
+                 * add in "arguments" this "String" attribute.
+                 */
+                
+                ServiceWsdl generator = new ServiceWsdl(modelURI, folder, arguments);
+                
+                /*
+                 * Add the properties from the launch arguments.
+                 * If you want to programmatically add new properties, add them in "propertiesFiles"
+                 * You can add the absolute path of a properties files, or even a project relative path.
+                 * If you want to add another "protocol" for your properties files, please override 
+                 * "getPropertiesLoaderService(AcceleoService)" in order to return a new property loader.
+                 * The behavior of the properties loader service is explained in the Acceleo documentation
+                 * (Help -> Help Contents).
+                 */
+                 
+                for (int i = 2; i < args.length; i++) {
+                    generator.addPropertiesFile(args[i]);
+                }
+                
+                generator.doGenerate(new BasicMonitor());
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Launches the generation described by this instance.
+     * 
+     * @param monitor
+     *            This will be used to display progress information to the user.
+     * @throws IOException
+     *             This will be thrown if any of the output files cannot be saved to disk.
+     * @generated
+     */
+    @Override
+    public void doGenerate(Monitor monitor) throws IOException {
+        /*
+         * TODO if you wish to change the generation as a whole, override this. The default behavior should
+         * be sufficient in most cases. If you want to change the content of this method, do NOT forget to
+         * change the "@generated" tag in the Javadoc of this method to "@generated NOT". Without this new tag,
+         * any compilation of the Acceleo module with the main template that has caused the creation of this
+         * class will revert your modifications. If you encounter a problem with an unresolved proxy during the
+         * generation, you can remove the comments in the following instructions to check for problems. Please
+         * note that those instructions may have a significant impact on the performances.
+         */
+
+        //org.eclipse.emf.ecore.util.EcoreUtil.resolveAll(model);
+
+        /*
+         * If you want to check for potential errors in your models before the launch of the generation, you
+         * use the code below.
+         */
+
+        //if (model != null && model.eResource() != null) {
+        //    List<org.eclipse.emf.ecore.resource.Resource.Diagnostic> errors = model.eResource().getErrors();
+        //    for (org.eclipse.emf.ecore.resource.Resource.Diagnostic diagnostic : errors) {
+        //        System.err.println(diagnostic.toString());
+        //    }
+        //}
+
+        super.doGenerate(monitor);
+    }
+    
+    /**
+     * If this generator needs to listen to text generation events, listeners can be returned from here.
+     * 
+     * @return List of listeners that are to be notified when text is generated through this launch.
+     * @generated
+     */
+    @Override
+    public List<IAcceleoTextGenerationListener> getGenerationListeners() {
+        List<IAcceleoTextGenerationListener> listeners = super.getGenerationListeners();
+        /*
+         * TODO if you need to listen to generation event, add listeners to the list here. If you want to change
+         * the content of this method, do NOT forget to change the "@generated" tag in the Javadoc of this method
+         * to "@generated NOT". Without this new tag, any compilation of the Acceleo module with the main template
+         * that has caused the creation of this class will revert your modifications.
+         */
+        return listeners;
+    }
+    
+    /**
+     * If you need to change the way files are generated, this is your entry point.
+     * <p>
+     * The default is {@link org.eclipse.acceleo.engine.generation.strategy.DefaultStrategy}; it generates
+     * files on the fly. If you only need to preview the results, return a new
+     * {@link org.eclipse.acceleo.engine.generation.strategy.PreviewStrategy}. Both of these aren't aware of
+     * the running Eclipse and can be used standalone.
+     * </p>
+     * <p>
+     * If you need the file generation to be aware of the workspace (A typical example is when you wanna
+     * override files that are under clear case or any other VCS that could forbid the overriding), then
+     * return a new {@link org.eclipse.acceleo.engine.generation.strategy.WorkspaceAwareStrategy}.
+     * <b>Note</b>, however, that this <b>cannot</b> be used standalone.
+     * </p>
+     * <p>
+     * All three of these default strategies support merging through JMerge.
+     * </p>
+     * 
+     * @return The generation strategy that is to be used for generations launched through this launcher.
+     * @generated
+     */
+    @Override
+    public IAcceleoGenerationStrategy getGenerationStrategy() {
+        return super.getGenerationStrategy();
+    }
+    
+    /**
+     * This will be called in order to find and load the module that will be launched through this launcher.
+     * We expect this name not to contain file extension, and the module to be located beside the launcher.
+     * 
+     * @return The name of the module that is to be launched.
+     * @generated
+     */
+    @Override
+    public String getModuleName() {
+        return MODULE_FILE_NAME;
+    }
+    
+    /**
+     * If the module(s) called by this launcher require properties files, return their qualified path from
+     * here.Take note that the first added properties files will take precedence over subsequent ones if they
+     * contain conflicting keys.
+     * 
+     * @return The list of properties file we need to add to the generation context.
+     * @see java.util.ResourceBundle#getBundle(String)
+     * @generated
+     */
+    @Override
+    public List<String> getProperties() {
+        /*
+         * If you want to change the content of this method, do NOT forget to change the "@generated"
+         * tag in the Javadoc of this method to "@generated NOT". Without this new tag, any compilation
+         * of the Acceleo module with the main template that has caused the creation of this class will
+         * revert your modifications.
+         */
+
+        /*
+         * TODO if your generation module requires access to properties files, add their qualified path to the list here.
+         * 
+         * Properties files can be located in an Eclipse plug-in or in the file system (all Acceleo projects are Eclipse
+         * plug-in). In order to use properties files located in an Eclipse plugin, you need to add the path of the properties
+         * files to the "propertiesFiles" list:
+         * 
+         * final String prefix = "platform:/plugin/";
+         * final String pluginName = "org.eclipse.acceleo.module.sample";
+         * final String packagePath = "/org/eclipse/acceleo/module/sample/properties/";
+         * final String fileName = "default.properties";
+         * propertiesFiles.add(prefix + pluginName + packagePath + fileName);
+         * 
+         * With this mechanism, you can load properties files from your plugin or from another plugin.
+         * 
+         * You may want to load properties files from the file system, for that you need to add the absolute path of the file:
+         * 
+         * propertiesFiles.add("C:\Users\MyName\MyFile.properties");
+         * 
+         * If you want to let your users add properties files located in the same folder as the model:
+         *
+         * if (EMFPlugin.IS_ECLIPSE_RUNNING && model != null && model.eResource() != null) { 
+         *     propertiesFiles.addAll(AcceleoEngineUtils.getPropertiesFilesNearModel(model.eResource()));
+         * }
+         * 
+         * To learn more about Properties Files, have a look at the Acceleo documentation (Help -> Help Contents).
+         */
+        return propertiesFiles;
+    }
+    
+    /**
+     * Adds a properties file in the list of properties files.
+     * 
+     * @param propertiesFile
+     *            The properties file to add.
+     * @generated
+     * @since 3.1
+     */
+    @Override
+    public void addPropertiesFile(String propertiesFile) {
+        this.propertiesFiles.add(propertiesFile);
+    }
+    
+    /**
+     * This will be used to get the list of templates that are to be launched by this launcher.
+     * 
+     * @return The list of templates to call on the module {@link #getModuleName()}.
+     * @generated
+     */
+    @Override
+    public String[] getTemplateNames() {
+        return TEMPLATE_NAMES;
+    }
+    
+    /**
+     * This can be used to update the resource set's package registry with all needed EPackages.
+     * 
+     * @param resourceSet
+     *            The resource set which registry has to be updated.
+     * @generated
+     */
+    @Override
+    public void registerPackages(ResourceSet resourceSet) {
+        super.registerPackages(resourceSet);
+        if (!isInWorkspace(org.obeonetwork.dsl.overview.OverviewPackage.class)) {
+            resourceSet.getPackageRegistry().put(org.obeonetwork.dsl.overview.OverviewPackage.eINSTANCE.getNsURI(), org.obeonetwork.dsl.overview.OverviewPackage.eINSTANCE);
+        }
+        if (!isInWorkspace(org.obeonetwork.dsl.soa.SoaPackage.class)) {
+            resourceSet.getPackageRegistry().put(org.obeonetwork.dsl.soa.SoaPackage.eINSTANCE.getNsURI(), org.obeonetwork.dsl.soa.SoaPackage.eINSTANCE);
+        }
+        
+        /*
+         * If you want to change the content of this method, do NOT forget to change the "@generated"
+         * tag in the Javadoc of this method to "@generated NOT". Without this new tag, any compilation
+         * of the Acceleo module with the main template that has caused the creation of this class will
+         * revert your modifications.
+         */
+        
+        /*
+         * If you need additional package registrations, you can register them here. The following line
+         * (in comment) is an example of the package registration for UML.
+         * 
+         * You can use the method  "isInWorkspace(Class c)" to check if the package that you are about to
+         * register is in the workspace.
+         * 
+         * To register a package properly, please follow the following conventions:
+         *
+         * If the package is located in another plug-in, already installed in Eclipse. The following content should
+         * have been generated at the beginning of this method. Do not register the package using this mechanism if
+         * the metamodel is located in the workspace.
+         *  
+         * if (!isInWorkspace(UMLPackage.class)) {
+         *     // The normal package registration if your metamodel is in a plugin.
+         *     resourceSet.getPackageRegistry().put(UMLPackage.eNS_URI, UMLPackage.eINSTANCE);
+         * }
+         * 
+         * If the package is located in another project in your workspace, the plugin containing the package has not
+         * been register by EMF and Acceleo should register it automatically. If you want to use the generator in
+         * stand alone, the regular registration (seen a couple lines before) is needed.
+         * 
+         * To learn more about Package Registration, have a look at the Acceleo documentation (Help -> Help Contents).
+         */
+    }
+
+    /**
+     * This can be used to update the resource set's resource factory registry with all needed factories.
+     * 
+     * @param resourceSet
+     *            The resource set which registry has to be updated.
+     * @generated
+     */
+    @Override
+    public void registerResourceFactories(ResourceSet resourceSet) {
+        super.registerResourceFactories(resourceSet);
+        /*
+         * If you want to change the content of this method, do NOT forget to change the "@generated"
+         * tag in the Javadoc of this method to "@generated NOT". Without this new tag, any compilation
+         * of the Acceleo module with the main template that has caused the creation of this class will
+         * revert your modifications.
+         */
+        
+        /*
+         * TODO If you need additional resource factories registrations, you can register them here. the following line
+         * (in comment) is an example of the resource factory registration for UML.
+         *
+         * If you want to use the generator in stand alone, the resource factory registration will be required.
+         *  
+         * To learn more about the registration of Resource Factories, have a look at the Acceleo documentation (Help -> Help Contents). 
+         */ 
+        
+        // resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put(UMLResource.FILE_EXTENSION, UMLResource.Factory.INSTANCE);
+    }
+    
+}

--- a/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/src/org/obeonetwork/dsl/soa/gen/contracts/main/dtoXsd.mtl
+++ b/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/src/org/obeonetwork/dsl/soa/gen/contracts/main/dtoXsd.mtl
@@ -1,0 +1,18 @@
+[comment encoding = UTF-8 /]
+[module dtoXsd('http://www.obeonetwork.org/dsl/overview/2.0.0', 'http://www.obeonetwork.org/dsl/soa/2.0.0')/]
+
+[import org::obeonetwork::dsl::soa::gen::contracts::files::xsdFile /]
+
+
+[template public dtoXsd(aRoot : Root)]
+[comment @main /]
+[aRoot.ownedElements.eAllContents(DTORegistry).generateDtoXsd()/]        
+[/template]
+
+[template public generateDtoXsd(aRegistry : DTORegistry)]
+[for (aCategory : Category | aRegistry.eAllContents(Category))]
+[file ('main/resources/' + aCategory.genFullPathFile(), false, 'UTF-8')]
+[aCategory.genXsdFileBody()/]
+[/file]
+[/for]
+[/template]

--- a/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/src/org/obeonetwork/dsl/soa/gen/contracts/main/generateAll.mtl
+++ b/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/src/org/obeonetwork/dsl/soa/gen/contracts/main/generateAll.mtl
@@ -1,0 +1,12 @@
+[comment encoding = UTF-8 /]
+[module generateAll('http://www.obeonetwork.org/dsl/overview/2.0.0')]
+
+[import org::obeonetwork::dsl::soa::gen::contracts::main::dtoXsd /]
+[import org::obeonetwork::dsl::soa::gen::contracts::main::serviceWsdl /]
+
+
+[template public generateAll(aRoot : Root)]
+[comment @main /]
+[aRoot.dtoXsd()/]
+[aRoot.serviceWsdl()/]
+[/template]

--- a/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/src/org/obeonetwork/dsl/soa/gen/contracts/main/serviceWsdl.mtl
+++ b/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/src/org/obeonetwork/dsl/soa/gen/contracts/main/serviceWsdl.mtl
@@ -1,0 +1,18 @@
+[comment encoding = UTF-8 /]
+[module serviceWsdl('http://www.obeonetwork.org/dsl/overview/2.0.0', 'http://www.obeonetwork.org/dsl/soa/2.0.0')/]
+
+[import org::obeonetwork::dsl::soa::gen::contracts::files::wsdlFile /]
+
+
+[template public serviceWsdl(aRoot : Root)]
+[comment @main /]
+[aRoot.ownedElements.eAllContents(Component).generateServiceWsdl()/]        
+[/template]
+
+[template public generateServiceWsdl(aComponent : Component)]
+[for (aService : Service | aComponent.ownedServices)]
+[file ('main/resources/' + aService.genFullPathFile(), false, 'UTF-8')]
+[aService.genWsdlFileBody()/]
+[/file]
+[/for]
+[/template]

--- a/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/src/org/obeonetwork/dsl/soa/gen/contracts/services/ConstraintsServices.java
+++ b/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/src/org/obeonetwork/dsl/soa/gen/contracts/services/ConstraintsServices.java
@@ -1,0 +1,181 @@
+package org.obeonetwork.dsl.soa.gen.contracts.services;
+         
+import org.eclipse.emf.common.util.EList;
+import org.obeonetwork.dsl.environment.Annotation;
+import org.obeonetwork.dsl.environment.MetaData;
+import org.obeonetwork.dsl.environment.ObeoDSMObject;
+/**
+ * A service that helps retrieving constraints posted on ObeoDSMObject.
+ * @author Laurent Broudoux
+ */
+public class ConstraintsServices {
+
+	/** The constructor. */
+	public ConstraintsServices(){
+        // prevent instantiation.
+    }
+	
+	public static int getStringConstraintMinLength(ObeoDSMObject dsmObject){
+		if (dsmObject.getMetadatas() != null){
+			return getStringConstraintMinLength(dsmObject.getMetadatas().getMetadatas());
+		}
+		return -1;
+	}
+	
+    private static int getStringConstraintMinLength(EList<MetaData> metadatas){
+    	for (MetaData metadata : metadatas){
+			// Find string constraint.
+			Annotation constraint = null;
+			if (metadata instanceof Annotation){
+				constraint = (Annotation)metadata;
+			}
+            if (constraint != null && constraint.getTitle().indexOf("@Size") != -1){
+                String value = null;
+                int minPos = constraint.getBody().indexOf("min=");
+                if (minPos != -1){
+                    int comPos = constraint.getBody().indexOf(',');
+                    // min=2, max=60
+                    if (minPos < comPos){
+                        value = constraint.getBody().substring(minPos + 4, comPos);
+                    }
+                    // max=60, min=2 or min=2
+                    else if (minPos > comPos){
+                        value = constraint.getBody().substring(minPos + 4, constraint.getBody().length());
+                    }
+                }
+                if (value != null){
+                    value = value.trim();
+                    try{
+                        return Integer.parseInt(value);
+                    } catch (NumberFormatException nfe){
+                        // Nothing to do here, default value (-1) will be returned.
+                    }
+                }
+            };
+        }
+		return -1;
+	}
+
+	public static int getStringConstraintMaxLength(ObeoDSMObject dsmObject){
+    	if (dsmObject.getMetadatas() != null){
+    		return getStringConstraintMaxLength(dsmObject.getMetadatas().getMetadatas());
+    	}
+    	return -1;
+	}
+	
+	private static int getStringConstraintMaxLength(EList<MetaData> metadatas) {
+    	for (MetaData metadata : metadatas){
+            // Find string constraint.
+    		Annotation constraint = null;
+			if (metadata instanceof Annotation){
+				constraint = (Annotation)metadata;
+			}
+            if (constraint != null && constraint.getTitle().indexOf("@Size") != -1){
+                String value = null;
+                int maxPos = constraint.getBody().indexOf("max=");
+                if (maxPos != -1){
+                    int comPos = constraint.getBody().indexOf(',');
+                    // max=60, min=2
+                    if (comPos > maxPos){
+                        value = constraint.getBody().substring(maxPos + 4, comPos);
+                    }
+                    // min=2, max=60 or max=60
+                    else if (maxPos > comPos){
+                        value = constraint.getBody().substring(maxPos + 4, constraint.getBody().length());
+                    }
+                }
+                if (value != null){
+                    value = value.trim();
+                    try{
+                        return Integer.parseInt(value);
+                    } catch (NumberFormatException nfe){
+                        // Nothing to do here, default value (-1) will be returned.
+                    }
+                }
+            }
+        }
+        return -1;
+    }
+   
+    public static int getIntegerConstraintMinValue(ObeoDSMObject dsmObject){
+    	if (dsmObject.getMetadatas() != null){
+    		return getIntegerConstraintMinValue(dsmObject.getMetadatas().getMetadatas());
+    	}
+    	return 55;
+    }
+    
+    private static int getIntegerConstraintMinValue(EList<MetaData> metadatas){
+        for (MetaData metadata : metadatas){
+            // Find integer constraint.
+        	Annotation constraint = null;
+			if (metadata instanceof Annotation){
+				constraint = (Annotation)metadata;
+			}
+            if (constraint != null && constraint.getTitle().indexOf("@Value") != -1){
+                String value = null;
+                int minPos = constraint.getBody().indexOf("min=");
+                if (minPos != -1){
+                    int comPos = constraint.getBody().indexOf(',');
+                    // min=2, max=60
+                    if (minPos < comPos){
+                        value = constraint.getBody().substring(minPos + 4, comPos);
+                    }
+                    // max=60, min=2 or min=2
+                    else if (comPos < minPos){
+                        value = constraint.getBody().substring(minPos + 4, constraint.getBody().length());
+                    }
+                }
+                if (value != null){
+                    value = value.trim();
+                    try{
+                        return Integer.parseInt(value);
+                    } catch (NumberFormatException nfe){
+                        // Nothing to do here, default value (-1) will be returned.
+                    }
+                }
+            }
+        }
+        return -1;
+    }
+   
+    public static int getIntegerConstraintMaxValue(ObeoDSMObject dsmObject){
+    	if (dsmObject.getMetadatas() != null){
+    		return getIntegerConstraintMaxValue(dsmObject.getMetadatas().getMetadatas());
+    	}
+    	return -1;
+    }
+    
+    private static int getIntegerConstraintMaxValue(EList<MetaData> metadatas){
+        for (MetaData metadata : metadatas){
+            // Find integer constraint.
+        	Annotation constraint = null;
+			if (metadata instanceof Annotation){
+				constraint = (Annotation)metadata;
+			}
+            if (constraint != null && constraint.getTitle().indexOf("@Value") != -1){
+                String value = null;
+                int maxPos = constraint.getBody().indexOf("max=");
+                if (maxPos != -1){
+                    int comPos = constraint.getBody().indexOf(',');
+                    // max=60, min=2
+                    if (maxPos < comPos){
+                        value = constraint.getBody().substring(maxPos + 4, comPos);
+                    }
+                    // min=2, max=60 or max=60
+                    else if (maxPos > comPos){
+                        value = constraint.getBody().substring(maxPos + 4, constraint.getBody().length());
+                    }
+                }
+                if (value != null){
+                    value = value.trim();
+                    try{
+                        return Integer.parseInt(value);
+                    } catch (NumberFormatException nfe){
+                        // Nothing to do here, default value (-1) will be returned.
+                    }
+                }
+            }
+        }
+        return -1;
+    }
+}

--- a/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/src/org/obeonetwork/dsl/soa/gen/contracts/services/NamespaceServices.java
+++ b/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/src/org/obeonetwork/dsl/soa/gen/contracts/services/NamespaceServices.java
@@ -1,0 +1,79 @@
+package org.obeonetwork.dsl.soa.gen.contracts.services;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.emf.ecore.EObject;
+import org.obeonetwork.dsl.soa.Category;
+import org.obeonetwork.dsl.soa.Service;
+import org.obeonetwork.dsl.soa.System;
+/**
+ * A service that helps building or retrieving namespaces and prefix associated
+ * to Service or Category domain objects.
+ * @author Laurent Broudoux
+ */
+public class NamespaceServices {
+
+	public static final String NAMESPACE_PREFIX_KEY = "nsPrefix";
+
+	private static Integer namespaceCounter = 1;
+
+	private static Map<String, String> namespacePrefix = new HashMap<String, String>();
+
+	/** The constructor. */
+	private NamespaceServices() {
+		// prevent instantiation.
+	}
+
+	public static void resetNamespaces() {
+		namespaceCounter = 1;
+		namespacePrefix.clear();
+	}
+
+	public static String getTargetNamespace(Service service) {
+		StringBuilder result = new StringBuilder(getNamespacePrefix());
+		// First add system name if any.
+		EObject container = service.eContainer();
+		if (container instanceof System) {
+			System system = (System) container;
+			result.append('/').append(system.getName());
+		}
+		// Then add service name.
+		result.append('/').append(service.getName());
+		return result.toString();
+	}
+
+	public static String getTargetNamespace(Category category) {
+		StringBuilder result = new StringBuilder(getNamespacePrefix());
+		StringBuilder categoryTree = new StringBuilder();
+		// First add system name if any.
+		EObject container = category.eContainer();
+		if (container instanceof System) {
+			System system = (System) container;
+			result.append('/').append(system.getName());
+		} else if (container instanceof Category) {
+			Category parent = (Category) container;
+			categoryTree.insert(0, parent.getName()).insert(0, '/');
+		}
+		// Then add category name.
+		result.append(categoryTree).append('/').append(category.getName());
+		return result.toString();
+	}
+
+	public static String getNamespacePrefix(Category category) {
+		String nsPrefix = namespacePrefix.get(category.getName());
+		if (nsPrefix == null) {
+			synchronized (namespaceCounter) {
+				nsPrefix = "ns" + namespaceCounter;
+				namespacePrefix.put(category.getName(), nsPrefix);
+				namespaceCounter++;
+			}
+		}
+		return nsPrefix;
+	}
+
+	public static String getNamespacePrefix() {
+		return java.lang.System.getProperty(NAMESPACE_PREFIX_KEY,
+				"http://www.github.com");
+	}
+}

--- a/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/src/org/obeonetwork/dsl/soa/gen/contracts/services/constraintsServices.mtl
+++ b/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/src/org/obeonetwork/dsl/soa/gen/contracts/services/constraintsServices.mtl
@@ -1,0 +1,19 @@
+[comment encoding = UTF-8 /]
+[module constraintsServices('http://www.obeonetwork.org/dsl/environment/2.0.0')]
+
+
+[query public getStringConstraintMinLength(dsmObject : ObeoDSMObject) : Integer
+   = invoke('org.obeonetwork.dsl.soa.gen.contracts.services.ConstraintsServices',
+   'getStringConstraintMinLength(org.obeonetwork.dsl.environment.ObeoDSMObject)', Sequence{dsmObject}) /]
+
+[query public getStringConstraintMaxLength(dsmObject : ObeoDSMObject) : Integer
+   = invoke('org.obeonetwork.dsl.soa.gen.contracts.services.ConstraintsServices',
+   'getStringConstraintMaxLength(org.obeonetwork.dsl.environment.ObeoDSMObject)', Sequence{dsmObject}) /]
+
+[query public getIntegerConstraintMinValue(dsmObject : ObeoDSMObject) : Integer
+   = invoke('org.obeonetwork.dsl.soa.gen.contracts.services.ConstraintsServices',
+   'getIntegerConstraintMinValue(org.obeonetwork.dsl.environment.ObeoDSMObject)', Sequence{dsmObject}) /]
+
+[query public getIntegerConstraintMaxValue(dsmObject : ObeoDSMObject) : Integer
+   = invoke('org.obeonetwork.dsl.soa.gen.contracts.services.ConstraintsServices',
+   'getIntegerConstraintMaxValue(org.obeonetwork.dsl.environment.ObeoDSMObject)', Sequence{dsmObject}) /]

--- a/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/src/org/obeonetwork/dsl/soa/gen/contracts/services/namespaceServices.mtl
+++ b/generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts/src/org/obeonetwork/dsl/soa/gen/contracts/services/namespaceServices.mtl
@@ -1,0 +1,18 @@
+[comment encoding = UTF-8 /]
+[module namespaceServices('http://www.obeonetwork.org/dsl/soa/2.0.0')]
+
+
+[template public getTargetNamespace(aService : Service) post (trim())]
+[invoke('org.obeonetwork.dsl.soa.gen.contracts.services.NamespaceServices',
+        'getTargetNamespace(org.obeonetwork.dsl.soa.Service)', Sequence{aService}) /]
+[/template]
+
+[template public getTargetNamespace(aCategory : Category) post (trim())]
+[invoke('org.obeonetwork.dsl.soa.gen.contracts.services.NamespaceServices',
+        'getTargetNamespace(org.obeonetwork.dsl.soa.Category)', Sequence{aCategory}) /]
+[/template]
+
+[template public getNamespacePrefix(aCategory : Category) post (trim())]
+[invoke('org.obeonetwork.dsl.soa.gen.contracts.services.NamespaceServices',
+        'getNamespacePrefix(org.obeonetwork.dsl.soa.Category)', Sequence{aCategory}) /]
+[/template]

--- a/generators/soa/tests/org.obeonetwork.dsl.soa.gen.contracts.test/.project
+++ b/generators/soa/tests/org.obeonetwork.dsl.soa.gen.contracts.test/.project
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.obeonetwork.dsl.soa.gen.contracts.test</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+		<nature>fr.obeo.dsl.viewpoint.nature.modelingproject</nature>
+	</natures>
+</projectDescription>

--- a/generators/soa/tests/org.obeonetwork.dsl.soa.gen.contracts.test/My.ois
+++ b/generators/soa/tests/org.obeonetwork.dsl.soa.gen.contracts.test/My.ois
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<overview:Root xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cinematic="http://www.obeonetwork.org/dsl/cinematic/3.0.0" xmlns:oent="http://www.obeonetwork.org/dsl/entity/2.0.0" xmlns:oenv="http://www.obeonetwork.org/dsl/environment/2.0.0" xmlns:org.obeonetwork.dsl.soa="http://www.obeonetwork.org/dsl/soa/2.0.0" xmlns:overview="http://www.obeonetwork.org/dsl/overview/2.0.0" xmi:id="_gjSAcFI1EeOAbOpuPpv3gw" createdOn="2013-11-20T23:45:52.247+0100" modifiedOn="2013-11-20T23:45:52.248+0100">
+  <ownedElements xsi:type="oent:Root" xmi:id="_gjSAcVI1EeOAbOpuPpv3gw" createdOn="2013-11-20T23:51:13.353+0100" modifiedOn="2013-11-20T23:51:13.353+0100">
+    <blocks xmi:id="_QZk8gFI2EeOAbOpuPpv3gw" createdOn="2013-11-20T23:51:23.596+0100" modifiedOn="2013-11-20T23:51:27.419+0100" name="Block_1">
+      <entities xmi:id="_SfuwsFI2EeOAbOpuPpv3gw" createdOn="2013-11-20T23:51:27.419+0100" modifiedOn="2013-11-20T23:54:06.987+0100" name="Entity_1">
+        <ownedAttributes xmi:id="_kEVP4FI2EeOAbOpuPpv3gw" createdOn="2013-11-20T23:53:25.342+0100" modifiedOn="2013-11-20T23:56:23.449+0100" name="attribute1">
+          <type href="platform:/plugin/org.obeonetwork.dsl.environment.common/model/obeo.environment#_s5F-EKwKEd2XLNOhkJIazw"/>
+        </ownedAttributes>
+        <ownedAttributes xmi:id="_qRfVsFI2EeOAbOpuPpv3gw" description="Description of attribute2" createdOn="2013-11-20T23:54:06.987+0100" modifiedOn="2013-11-21T21:58:11.744+0100" name="attribute2" multiplicity="1">
+          <metadatas xmi:id="_odu6AVLvEeO3S-QDJvhruQ">
+            <metadatas xsi:type="oenv:Annotation" xmi:id="_odxWQFLvEeO3S-QDJvhruQ" title="@Value" body="max=9999, min=100"/>
+          </metadatas>
+          <type href="platform:/plugin/org.obeonetwork.dsl.environment.common/model/obeo.environment#_s5FXAawKEd2XLNOhkJIazw"/>
+        </ownedAttributes>
+      </entities>
+    </blocks>
+  </ownedElements>
+  <ownedElements xsi:type="org.obeonetwork.dsl.soa:System" xmi:id="_gjSngFI1EeOAbOpuPpv3gw" createdOn="2013-11-20T23:57:05.630+0100" modifiedOn="2013-11-21T00:26:08.968+0100" name="MySystem">
+    <ownedComponents xmi:id="_VBV8YFI3EeOAbOpuPpv3gw" createdOn="2013-11-20T23:58:53.865+0100" modifiedOn="2013-11-20T23:59:25.653+0100" name="Component_1">
+      <ownedServices xmi:id="_ZwhoUFI3EeOAbOpuPpv3gw" createdOn="2013-11-20T23:59:25.655+0100" modifiedOn="2013-11-21T00:05:03.117+0100" name="ProvidedService1">
+        <ownedInterface xmi:id="_MC1T0FI4EeOAbOpuPpv3gw" createdOn="2013-11-21T00:05:03.118+0100" modifiedOn="2013-11-21T00:05:12.709+0100" name="ProvidedService1">
+          <ownedOperations xmi:id="_MC2h8FI4EeOAbOpuPpv3gw" createdOn="2013-11-21T00:05:03.119+0100" modifiedOn="2013-11-21T00:10:36.703+0100" name="requestResponse">
+            <input xmi:id="_THbX8FI4EeOAbOpuPpv3gw" createdOn="2013-11-21T00:05:50.577+0100" modifiedOn="2013-11-21T00:07:25.900+0100" type="_pCjA4FI3EeOAbOpuPpv3gw" name="entity"/>
+            <input xmi:id="_htzLcFI4EeOAbOpuPpv3gw" createdOn="2013-11-21T00:07:28.552+0100" modifiedOn="2013-11-21T00:10:58.493+0100" name="primitiveString" lower="0">
+              <metadatas xmi:id="_jiFMgFI4EeOAbOpuPpv3gw">
+                <metadatas xsi:type="oenv:Annotation" xmi:id="_jiFMgVI4EeOAbOpuPpv3gw" title="@Size" body="min=2, max=20"/>
+              </metadatas>
+              <type xsi:type="oenv:PrimitiveType" href="platform:/plugin/org.obeonetwork.dsl.environment.common/model/obeo.environment#_s5F-EKwKEd2XLNOhkJIazw"/>
+            </input>
+            <output xmi:id="_sJtJoFI4EeOAbOpuPpv3gw" createdOn="2013-11-21T00:08:38.587+0100" modifiedOn="2013-11-21T00:09:13.538+0100" type="_sJ5MUFI3EeOAbOpuPpv3gw" name="output1"/>
+            <fault xmi:id="_9wKC8FI4EeOAbOpuPpv3gw" createdOn="2013-11-21T00:10:36.704+0100" modifiedOn="2013-11-21T00:10:44.818+0100" name="faultString">
+              <type xsi:type="oenv:PrimitiveType" href="platform:/plugin/org.obeonetwork.dsl.environment.common/model/obeo.environment#_s5F-EKwKEd2XLNOhkJIazw"/>
+            </fault>
+          </ownedOperations>
+          <ownedOperations xmi:id="_NeTzUFI4EeOAbOpuPpv3gw" createdOn="2013-11-21T00:05:12.709+0100" modifiedOn="2013-11-21T00:09:35.848+0100" name="oneWay" kind="ONE_WAY">
+            <input xmi:id="_0ryfcFI4EeOAbOpuPpv3gw" createdOn="2013-11-21T00:09:35.849+0100" modifiedOn="2013-11-21T00:10:10.921+0100" type="_9VqUwFI3EeOAbOpuPpv3gw" name="composite"/>
+          </ownedOperations>
+        </ownedInterface>
+      </ownedServices>
+    </ownedComponents>
+    <ownedDtoRegistry xmi:id="_E5KX4FI3EeOAbOpuPpv3gw" createdOn="2013-11-20T23:59:48.890+0100" modifiedOn="2013-11-20T23:59:59.097+0100">
+      <ownedCategories xmi:id="_dOIXoFI3EeOAbOpuPpv3gw" description="Category_1 description" createdOn="2013-11-20T23:59:48.895+0100" modifiedOn="2013-11-21T00:32:56.039+0100" name="Category_1">
+        <types xsi:type="org.obeonetwork.dsl.soa:ServiceDTO" xmi:id="_pCjA4FI3EeOAbOpuPpv3gw" createdOn="2013-11-21T00:01:08.206+0100" modifiedOn="2013-11-21T00:01:08.208+0100" name="Entity_1DTO" associatedTypes="_SfuwsFI2EeOAbOpuPpv3gw"/>
+        <types xsi:type="org.obeonetwork.dsl.soa:ServiceDTO" xmi:id="_sJ5MUFI3EeOAbOpuPpv3gw" createdOn="2013-11-21T00:01:29.110+0100" modifiedOn="2013-11-21T00:01:57.954+0100" name="BasicDTO">
+          <ownedAttributes xmi:id="_urRj8FI3EeOAbOpuPpv3gw" description="Description of foo" createdOn="2013-11-21T00:01:46.031+0100" modifiedOn="2013-11-21T01:05:16.480+0100" name="foo">
+            <metadatas xmi:id="_mejEAFJAEeOAbOpuPpv3gw">
+              <metadatas xsi:type="oenv:Annotation" xmi:id="_mejEAVJAEeOAbOpuPpv3gw" title="@Size" body="min=2, max=10"/>
+            </metadatas>
+            <type href="platform:/plugin/org.obeonetwork.dsl.environment.common/model/obeo.environment#_s5F-EKwKEd2XLNOhkJIazw"/>
+          </ownedAttributes>
+          <ownedAttributes xmi:id="_wc-yIFI3EeOAbOpuPpv3gw" createdOn="2013-11-21T00:01:57.954+0100" modifiedOn="2013-11-21T00:02:08.276+0100" name="bar" multiplicity="1">
+            <type href="platform:/plugin/org.obeonetwork.dsl.environment.common/model/obeo.environment#_s5F-E6wKEd2XLNOhkJIazw"/>
+          </ownedAttributes>
+        </types>
+        <ownedCategories xmi:id="_gTxS4FI3EeOAbOpuPpv3gw" createdOn="2013-11-21T00:00:09.616+0100" modifiedOn="2013-11-21T00:02:35.278+0100" name="SubCategory_1">
+          <types xsi:type="org.obeonetwork.dsl.soa:ServiceDTO" xmi:id="_2A670FI3EeOAbOpuPpv3gw" createdOn="2013-11-21T00:02:35.278+0100" modifiedOn="2013-11-23T18:09:39.863+0100" name="BasicExtDTO" supertype="_sJ5MUFI3EeOAbOpuPpv3gw">
+            <ownedAttributes xmi:id="_6hN3MFI3EeOAbOpuPpv3gw" createdOn="2013-11-21T00:03:05.507+0100" modifiedOn="2013-11-21T00:03:13.569+0100" name="qix" multiplicity="0..*">
+              <type href="platform:/plugin/org.obeonetwork.dsl.environment.common/model/obeo.environment#_s5F-EKwKEd2XLNOhkJIazw"/>
+            </ownedAttributes>
+            <ownedAttributes xmi:id="_CcQTYVRiEeO0R-BciGkzVQ" description="Foo2 attribute description" createdOn="2013-11-23T18:09:39.862+0100" modifiedOn="2013-11-23T18:10:03.903+0100" name="foo2">
+              <metadatas xmi:id="_GBhw8FRiEeO0R-BciGkzVQ">
+                <metadatas xsi:type="oenv:Annotation" xmi:id="_GBiYAFRiEeO0R-BciGkzVQ" title="@Size" body="max=20, min=3"/>
+              </metadatas>
+              <type href="platform:/plugin/org.obeonetwork.dsl.environment.common/model/obeo.environment#_s5F-EKwKEd2XLNOhkJIazw"/>
+            </ownedAttributes>
+          </types>
+        </ownedCategories>
+      </ownedCategories>
+      <ownedCategories xmi:id="_eveOkFI3EeOAbOpuPpv3gw" createdOn="2013-11-20T23:59:59.099+0100" modifiedOn="2013-11-21T00:03:24.428+0100" name="Category_2">
+        <types xsi:type="org.obeonetwork.dsl.soa:ServiceDTO" xmi:id="_9VqUwFI3EeOAbOpuPpv3gw" createdOn="2013-11-21T00:03:24.428+0100" modifiedOn="2013-11-21T00:04:12.732+0100" name="CompositeDTO">
+          <ownedReferences xmi:id="_A15hUFI4EeOAbOpuPpv3gw" createdOn="2013-11-21T00:03:47.941+0100" modifiedOn="2013-11-21T00:04:05.101+0100" name="basicExt" isComposite="true" navigable="true" type="_2A670FI3EeOAbOpuPpv3gw"/>
+          <ownedReferences xmi:id="_EiUvwFI4EeOAbOpuPpv3gw" createdOn="2013-11-21T00:04:12.732+0100" modifiedOn="2013-11-21T00:04:23.274+0100" name="basic" multiplicity="0..*" navigable="true" type="_sJ5MUFI3EeOAbOpuPpv3gw"/>
+        </types>
+      </ownedCategories>
+    </ownedDtoRegistry>
+  </ownedElements>
+  <ownedElements xsi:type="cinematic:CinematicRoot" xmi:id="_gjSngVI1EeOAbOpuPpv3gw"/>
+</overview:Root>

--- a/generators/soa/tests/org.obeonetwork.dsl.soa.gen.contracts.test/main/resources/MySystem-Category_1-v1.xsd
+++ b/generators/soa/tests/org.obeonetwork.dsl.soa.gen.contracts.test/main/resources/MySystem-Category_1-v1.xsd
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.github.com/Category_1" xmlns:tns="http://www.github.com/Category_1"
+>
+  <xs:annotation>
+    <xs:documentation>
+      Category_1 description
+    </xs:documentation>
+  </xs:annotation>
+  <xs:complexType name="Entity_1DTO">
+      <xs:sequence>
+        <xs:element name="attribute1" type="xs:string" minOccurs="0">
+          
+        </xs:element>
+        <xs:element name="attribute2" >
+          <xs:annotation>
+            <xs:documentation>
+              Description of attribute2
+            </xs:documentation>
+          </xs:annotation>
+          <xs:simpleType>
+            <xs:restriction base="xs:int">
+              <xs:minInclusive value="100"></xs:minInclusive>
+              <xs:maxInclusive value="9999"></xs:maxInclusive>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="BasicDTO">
+      <xs:sequence>
+        <xs:element name="foo" minOccurs="0">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:minLength value="2"></xs:minLength>
+              <xs:maxLength value="10"></xs:maxLength>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="bar" type="xs:dateTime" ></xs:element>
+      </xs:sequence>
+    </xs:complexType>
+</xs:schema>

--- a/generators/soa/tests/org.obeonetwork.dsl.soa.gen.contracts.test/main/resources/MySystem-Category_2-v1.xsd
+++ b/generators/soa/tests/org.obeonetwork.dsl.soa.gen.contracts.test/main/resources/MySystem-Category_2-v1.xsd
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.github.com/Category_2" xmlns:tns="http://www.github.com/Category_2"
+    xmlns:ns2="http://www.github.com/Category_1/SubCategory_1"
+    xmlns:ns1="http://www.github.com/Category_1"
+>
+  <xs:import schemaLocation="MySystem-SubCategory_1-v1.xsd" namespace="http://www.github.com/Category_1/SubCategory_1"></xs:import>
+  <xs:import schemaLocation="MySystem-Category_1-v1.xsd" namespace="http://www.github.com/Category_1"></xs:import>
+  
+  <xs:complexType name="CompositeDTO">
+      <xs:sequence>
+        <xs:element name="basicExt" type="ns2:BasicExtDTO" minOccurs="0"></xs:element>
+        <xs:element name="basics">
+          
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="basic" type="ns1:BasicDTO" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+</xs:schema>

--- a/generators/soa/tests/org.obeonetwork.dsl.soa.gen.contracts.test/main/resources/MySystem-SubCategory_1-v1.xsd
+++ b/generators/soa/tests/org.obeonetwork.dsl.soa.gen.contracts.test/main/resources/MySystem-SubCategory_1-v1.xsd
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.github.com/Category_1/SubCategory_1" xmlns:tns="http://www.github.com/Category_1/SubCategory_1"
+    xmlns:ns1="http://www.github.com/Category_1"
+>
+  <xs:import schemaLocation="MySystem-Category_1-v1.xsd" namespace="http://www.github.com/Category_1"></xs:import>
+  
+  <xs:complexType name="BasicExtDTO">
+      <xs:complexContent>
+        <xs:extension base="ns1:BasicDTO">
+          <xs:sequence>
+            <xs:element name="qix" type="xs:string" minOccurs="0" maxOccurs="unbounded"></xs:element>
+            <xs:element name="foo2" minOccurs="0">
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                  <xs:minLength value="3"></xs:minLength>
+                  <xs:maxLength value="20"></xs:maxLength>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:element>
+          </xs:sequence>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+</xs:schema>

--- a/generators/soa/tests/org.obeonetwork.dsl.soa.gen.contracts.test/main/resources/ProvidedService1-v1.wsdl
+++ b/generators/soa/tests/org.obeonetwork.dsl.soa.gen.contracts.test/main/resources/ProvidedService1-v1.wsdl
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" name="ProvidedService1"
+        xmlns:tns="http://www.github.com/ProvidedService1" targetNamespace="http://www.github.com/ProvidedService1">
+  <wsdl:types>
+    <xsd:schema targetNamespace="http://www.github.com/ProvidedService1"
+        xmlns:ns1="http://www.github.com/Category_1"
+        xmlns:ns3="http://www.github.com/Category_2"
+    >
+      <xsd:import schemaLocation="MySystem-Category_1-v1.xsd" namespace="http://www.github.com/Category_1"></xsd:import>
+      <xsd:import schemaLocation="MySystem-Category_2-v1.xsd" namespace="http://www.github.com/Category_2"></xsd:import>
+      <xsd:element name="requestResponse">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="entity" type="ns1:Entity_1DTO"
+              minOccurs="1" maxOccurs="1"/>
+            <xsd:element name="primitiveString" type="xsd:string"
+              minOccurs="0" maxOccurs="1"/>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="requestResponseResponse">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="output1" type="ns1:BasicDTO"
+              minOccurs="1" maxOccurs="1"/>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="requestResponsefaultString" type="xsd:string"/>
+      <xsd:element name="oneWay">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="composite" type="ns3:CompositeDTO"
+              minOccurs="1" maxOccurs="1"/>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:schema>
+  </wsdl:types>
+  
+  <wsdl:message name="requestResponseRequest">
+    <wsdl:part element="tns:requestResponse" name="parameters"/>
+  </wsdl:message>
+  <wsdl:message name="requestResponseResponse">
+    <wsdl:part element="tns:requestResponseResponse" name="parameters"/>
+  </wsdl:message>
+  <wsdl:message name="requestResponsefaultString">
+    <wsdl:part element="tns:requestResponsefaultString" name="parameters"/> 
+  </wsdl:message>
+  <wsdl:message name="oneWayRequest">
+    <wsdl:part element="tns:oneWay" name="parameters"/>
+  </wsdl:message>
+  
+  <wsdl:binding name="ProvidedService1SOAP" type="tns:ProvidedService1">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="requestResponse">
+      <soap:operation soapAction="http://www.github.com/ProvidedService1/requestResponse"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="faultString"></wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="oneWay">
+      <soap:operation soapAction="http://www.github.com/ProvidedService1/oneWay"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:portType name="ProvidedService1">
+    <wsdl:operation name="requestResponse">
+      <wsdl:input message="tns:requestResponseRequest"/>
+      <wsdl:output message="tns:requestResponseResponse"/>
+      <wsdl:fault name="faultString" message="tns:requestResponsefaultString"/>
+    </wsdl:operation>
+    <wsdl:operation name="oneWay">
+      <wsdl:input message="tns:oneWayRequest"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:service name="ProvidedService1">
+    <wsdl:port binding="tns:ProvidedService1SOAP" name="ProvidedService1Port">
+      <soap:address location="http://www.example.org/"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/generators/soa/tests/org.obeonetwork.dsl.soa.gen.contracts.test/representations.aird
+++ b/generators/soa/tests/org.obeonetwork.dsl.soa.gen.contracts.test/representations.aird
@@ -1,0 +1,804 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<viewpoint:DAnalysis xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cinematic="http://www.obeonetwork.org/dsl/cinematic/3.0.0" xmlns:description="http://www.obeo.fr/dsl/viewpoint/description/1.1.0" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:oent="http://www.obeonetwork.org/dsl/entity/2.0.0" xmlns:oenv="http://www.obeonetwork.org/dsl/environment/2.0.0" xmlns:org.obeonetwork.dsl.soa="http://www.obeonetwork.org/dsl/soa/2.0.0" xmlns:overview="http://www.obeonetwork.org/dsl/overview/2.0.0" xmlns:style="http://www.obeo.fr/dsl/viewpoint/description/style/1.1.0" xmlns:viewpoint="http://www.obeo.fr/dsl/viewpoint/1.1.0" xmlns:xsd="http://www.eclipse.org/xsd/2002/XSD" xsi:schemaLocation="http://www.obeo.fr/dsl/viewpoint/description/1.1.0 http://www.obeo.fr/dsl/viewpoint/1.1.0#//description http://www.obeo.fr/dsl/viewpoint/description/style/1.1.0 http://www.obeo.fr/dsl/viewpoint/1.1.0#//description/style" xmi:id="_eTIiwFI1EeOAbOpuPpv3gw" selectedViews="_iDmjsFI1EeOAbOpuPpv3gw _iFVCAFI1EeOAbOpuPpv3gw _iFc90FI1EeOAbOpuPpv3gw">
+  <models xmi:type="overview:Root" href="My.ois#_gjSAcFI1EeOAbOpuPpv3gw"/>
+  <models xmi:type="oenv:Environment" href="platform:/plugin/org.obeonetwork.dsl.environment.common/model/obeo.environment#_s5Ev8KwKEd2XLNOhkJIazw"/>
+  <models xmi:type="xsd:XSDSchema" href="main/resources/MySystem-Category_1-v1.xsd#/"/>
+  <models xmi:type="xsd:XSDSchema" href="bundleentry://581.fwk954049115/cache/www.w3.org/2001/XMLSchema-instance.xsd#/"/>
+  <models xmi:type="xsd:XSDSchema" href="bundleentry://581.fwk954049115/cache/www.w3.org/2001/XMLSchema.xsd#/"/>
+  <models xmi:type="xsd:XSDSchema" href="main/resources/MySystem-Category_2-v1.xsd#/"/>
+  <models xmi:type="xsd:XSDSchema" href="main/resources/MySystem-SubCategory_1-v1.xsd#/"/>
+  <eAnnotations xmi:type="description:DAnnotationEntry" xmi:id="_eTIiwVI1EeOAbOpuPpv3gw" source="Migration">
+    <details>style</details>
+    <details>someViewsAreHiddenDeactivation</details>
+    <details>edgeLabels</details>
+    <details>LabelAlignmentForDNodeListElementMigrationForNotHavingSessionDirtyAtOpening</details>
+    <details>LabelAlignmentForDNodeMigrationForNotHavingSessionDirtyAtOpening</details>
+    <details>GMFViewSizeForDNodeNotResizable</details>
+    <details>GMFTreeEdgeFixAnchors_2</details>
+    <details>RoutingStyleDesynchronization</details>
+    <details>sequenceAbsoluteBoundsFlag</details>
+  </eAnnotations>
+  <ownedViews xmi:type="viewpoint:DRepresentationContainer" xmi:id="_iDmjsFI1EeOAbOpuPpv3gw" initialized="true">
+    <ownedRepresentations xmi:type="viewpoint:DSemanticDiagram" xmi:id="_E5PQYFI3EeOAbOpuPpv3gw" name=" SOA Diagram">
+      <ownedAnnotationEntries xmi:type="description:AnnotationEntry" xmi:id="_E5YaUFI3EeOAbOpuPpv3gw" source="GMF_DIAGRAMS">
+        <data xmi:type="notation:Diagram" xmi:id="_E5YaUVI3EeOAbOpuPpv3gw" type="Viewpoint" element="_E5PQYFI3EeOAbOpuPpv3gw" measurementUnit="Pixel">
+          <children xmi:type="notation:Node" xmi:id="_E6MSoFI3EeOAbOpuPpv3gw" type="2002" element="_E6IBMFI3EeOAbOpuPpv3gw">
+            <children xmi:type="notation:Node" xmi:id="_E6NgwFI3EeOAbOpuPpv3gw" type="5006"/>
+            <children xmi:type="notation:Node" xmi:id="_E6NgwVI3EeOAbOpuPpv3gw" type="7001">
+              <styles xmi:type="notation:SortingStyle" xmi:id="_E6NgwlI3EeOAbOpuPpv3gw"/>
+              <styles xmi:type="notation:FilteringStyle" xmi:id="_E6Ngw1I3EeOAbOpuPpv3gw"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_E6MSoVI3EeOAbOpuPpv3gw" fontName="Sans" fontHeight="8" bold="true"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E6MSolI3EeOAbOpuPpv3gw" x="240" y="35"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_VB8ZUFI3EeOAbOpuPpv3gw" type="2002" element="_VBYYoFI3EeOAbOpuPpv3gw">
+            <children xmi:type="notation:Node" xmi:id="_VB9ncFI3EeOAbOpuPpv3gw" type="5006"/>
+            <children xmi:type="notation:Node" xmi:id="_VB9ncVI3EeOAbOpuPpv3gw" type="7001">
+              <styles xmi:type="notation:SortingStyle" xmi:id="_VB9nclI3EeOAbOpuPpv3gw"/>
+              <styles xmi:type="notation:FilteringStyle" xmi:id="_VB9nc1I3EeOAbOpuPpv3gw"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_ZxBXkFI3EeOAbOpuPpv3gw" type="3012" element="_ZwkroFI3EeOAbOpuPpv3gw">
+              <children xmi:type="notation:Node" xmi:id="_ZxDMwFI3EeOAbOpuPpv3gw" type="5010">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_ZxDMwVI3EeOAbOpuPpv3gw" x="21" y="5"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_ZxHeMFI3EeOAbOpuPpv3gw" type="3005" element="_ZwkroVI3EeOAbOpuPpv3gw">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_ZxHeMVI3EeOAbOpuPpv3gw" fontName="Sans"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZxHeMlI3EeOAbOpuPpv3gw"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_ZxBXkVI3EeOAbOpuPpv3gw" fontName="Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZxBXklI3EeOAbOpuPpv3gw" x="-12" y="40" width="20" height="20"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_VB8ZUVI3EeOAbOpuPpv3gw" fontName="Sans" fontHeight="8" bold="true"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_VB8ZUlI3EeOAbOpuPpv3gw" x="150" y="165" width="188" height="98"/>
+          </children>
+          <styles xmi:type="notation:DiagramStyle" xmi:id="_E5YaUlI3EeOAbOpuPpv3gw"/>
+        </data>
+      </ownedAnnotationEntries>
+      <ownedDiagramElements xmi:type="viewpoint:DNodeContainer" xmi:id="_E6IBMFI3EeOAbOpuPpv3gw" name="DTO Registry">
+        <target xmi:type="org.obeonetwork.dsl.soa:DTORegistry" href="My.ois#_E5KX4FI3EeOAbOpuPpv3gw"/>
+        <semanticElements xmi:type="org.obeonetwork.dsl.soa:DTORegistry" href="My.ois#_E5KX4FI3EeOAbOpuPpv3gw"/>
+        <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+        <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+        <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+        <ownedStyle xmi:type="viewpoint:FlatContainerStyle" xmi:id="_E6IoQFI3EeOAbOpuPpv3gw" labelFormat="bold" backgroundStyle="Liquid">
+          <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_E6IoQVI3EeOAbOpuPpv3gw"/>
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='SOA%20Diagram']/@optionalLayers[name='DTO%20Registry']/@containerMappings[name='SOAD_DtoRegistry']/@style"/>
+          <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_E6IoQlI3EeOAbOpuPpv3gw" red="77" green="137" blue="20"/>
+          <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_E6IoQ1I3EeOAbOpuPpv3gw" red="255" green="255" blue="255"/>
+          <foregroundColor xmi:type="viewpoint:RGBValues" xmi:id="_E6IoRFI3EeOAbOpuPpv3gw" red="138" green="226" blue="52"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description:ContainerMapping" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='SOA%20Diagram']/@optionalLayers[name='DTO%20Registry']/@containerMappings[name='SOAD_DtoRegistry']"/>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="viewpoint:DNodeContainer" xmi:id="_VBYYoFI3EeOAbOpuPpv3gw" name="Component_1">
+        <target xmi:type="org.obeonetwork.dsl.soa:Component" href="My.ois#_VBV8YFI3EeOAbOpuPpv3gw"/>
+        <semanticElements xmi:type="org.obeonetwork.dsl.soa:Component" href="My.ois#_VBV8YFI3EeOAbOpuPpv3gw"/>
+        <ownedBorderedNodes xmi:type="viewpoint:DNode" xmi:id="_ZwkroFI3EeOAbOpuPpv3gw" name="ProvidedService1" width="2" height="2">
+          <target xmi:type="org.obeonetwork.dsl.soa:Service" href="My.ois#_ZwhoUFI3EeOAbOpuPpv3gw"/>
+          <semanticElements xmi:type="org.obeonetwork.dsl.soa:Service" href="My.ois#_ZwhoUFI3EeOAbOpuPpv3gw"/>
+          <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+          <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+          <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+          <ownedStyle xmi:type="viewpoint:WorkspaceImage" xmi:id="_ZwkroVI3EeOAbOpuPpv3gw" showIcon="false" workspacePath="/org.obeonetwork.dsl.soa.edit/icons/full/obj16/Service.gif">
+            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_ZwlSsFI3EeOAbOpuPpv3gw"/>
+            <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='SOA%20Diagram']/@defaultLayer/@containerMappings[name='SOAD_Component']/@borderedNodeMappings[name='SOAD_Service_Provided']/@style"/>
+            <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_ZwlSsVI3EeOAbOpuPpv3gw"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description:NodeMapping" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='SOA%20Diagram']/@defaultLayer/@containerMappings[name='SOAD_Component']/@borderedNodeMappings[name='SOAD_Service_Provided']"/>
+        </ownedBorderedNodes>
+        <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+        <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+        <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+        <ownedStyle xmi:type="viewpoint:FlatContainerStyle" xmi:id="_VBY_sFI3EeOAbOpuPpv3gw" labelFormat="bold" showIcon="false" backgroundStyle="Liquid">
+          <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_VBY_sVI3EeOAbOpuPpv3gw"/>
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='SOA%20Diagram']/@defaultLayer/@containerMappings[name='SOAD_Component']/@style"/>
+          <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_VBY_slI3EeOAbOpuPpv3gw" red="39" green="76" blue="114"/>
+          <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_VBY_s1I3EeOAbOpuPpv3gw" red="255" green="255" blue="255"/>
+          <foregroundColor xmi:type="viewpoint:RGBValues" xmi:id="_VBY_tFI3EeOAbOpuPpv3gw" red="114" green="159" blue="207"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description:ContainerMapping" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='SOA%20Diagram']/@defaultLayer/@containerMappings[name='SOAD_Component']"/>
+      </ownedDiagramElements>
+      <description xmi:type="description:DiagramDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='SOA%20Diagram']"/>
+      <filterVariableHistory xmi:type="viewpoint:FilterVariableHistory" xmi:id="_E5PQYVI3EeOAbOpuPpv3gw"/>
+      <activatedLayers xmi:type="description:Layer" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='SOA%20Diagram']/@defaultLayer"/>
+      <activatedLayers xmi:type="description:OptionalLayer" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='SOA%20Diagram']/@optionalLayers[name='DTO%20Registry']"/>
+      <target xmi:type="org.obeonetwork.dsl.soa:System" href="My.ois#_gjSngFI1EeOAbOpuPpv3gw"/>
+    </ownedRepresentations>
+    <ownedRepresentations xmi:type="viewpoint:DSemanticDiagram" xmi:id="_cWoH4FI3EeOAbOpuPpv3gw" name="DTO View">
+      <ownedAnnotationEntries xmi:type="description:AnnotationEntry" xmi:id="_cWwDsFI3EeOAbOpuPpv3gw" source="GMF_DIAGRAMS">
+        <data xmi:type="notation:Diagram" xmi:id="_cWwDsVI3EeOAbOpuPpv3gw" type="Viewpoint" element="_cWoH4FI3EeOAbOpuPpv3gw" measurementUnit="Pixel">
+          <children xmi:type="notation:Node" xmi:id="_dOsYUFI3EeOAbOpuPpv3gw" type="2002" element="_dOMpEFI3EeOAbOpuPpv3gw">
+            <children xmi:type="notation:Node" xmi:id="_dOtmcFI3EeOAbOpuPpv3gw" type="5006"/>
+            <children xmi:type="notation:Node" xmi:id="_dOtmcVI3EeOAbOpuPpv3gw" type="7001">
+              <children xmi:type="notation:Node" xmi:id="_gUVTkFI3EeOAbOpuPpv3gw" type="3008" element="_gTzIEFI3EeOAbOpuPpv3gw">
+                <children xmi:type="notation:Node" xmi:id="_gUXIwFI3EeOAbOpuPpv3gw" type="5005"/>
+                <children xmi:type="notation:Node" xmi:id="_gUXv0FI3EeOAbOpuPpv3gw" type="7002">
+                  <children xmi:type="notation:Node" xmi:id="_2Bj1AFI3EeOAbOpuPpv3gw" type="3009" element="_2A8xAFI3EeOAbOpuPpv3gw">
+                    <children xmi:type="notation:Node" xmi:id="_2BkcEFI3EeOAbOpuPpv3gw" type="5004"/>
+                    <children xmi:type="notation:Node" xmi:id="_2BlDIFI3EeOAbOpuPpv3gw" type="7003">
+                      <children xmi:type="notation:Node" xmi:id="_6iC9oFI3EeOAbOpuPpv3gw" type="3010" element="_6hQTcFI3EeOAbOpuPpv3gw">
+                        <layoutConstraint xmi:type="notation:Location" xmi:id="_6iC9oVI3EeOAbOpuPpv3gw"/>
+                      </children>
+                      <styles xmi:type="notation:SortingStyle" xmi:id="_2BlDIVI3EeOAbOpuPpv3gw"/>
+                      <styles xmi:type="notation:FilteringStyle" xmi:id="_2BlDIlI3EeOAbOpuPpv3gw"/>
+                    </children>
+                    <styles xmi:type="notation:ShapeStyle" xmi:id="_2Bj1AVI3EeOAbOpuPpv3gw" fontName="Sans" fontHeight="8"/>
+                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2Bj1AlI3EeOAbOpuPpv3gw" x="45" y="39" width="138" height="68"/>
+                  </children>
+                  <styles xmi:type="notation:SortingStyle" xmi:id="_gUXv0VI3EeOAbOpuPpv3gw"/>
+                  <styles xmi:type="notation:FilteringStyle" xmi:id="_gUXv0lI3EeOAbOpuPpv3gw"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_gUVTkVI3EeOAbOpuPpv3gw" fontName="Sans" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_gUVTklI3EeOAbOpuPpv3gw" x="330" y="59" width="223" height="138"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_pDmJwFI3EeOAbOpuPpv3gw" type="3009" element="_pDTO0FI3EeOAbOpuPpv3gw">
+                <children xmi:type="notation:Node" xmi:id="_pDn-8FI3EeOAbOpuPpv3gw" type="5004"/>
+                <children xmi:type="notation:Node" xmi:id="_pDn-8VI3EeOAbOpuPpv3gw" type="7003">
+                  <children xmi:type="notation:Node" xmi:id="_pDomAFI3EeOAbOpuPpv3gw" type="3010" element="_pDXgQFI3EeOAbOpuPpv3gw">
+                    <layoutConstraint xmi:type="notation:Location" xmi:id="_pDomAVI3EeOAbOpuPpv3gw"/>
+                  </children>
+                  <children xmi:type="notation:Node" xmi:id="_pDpNEFI3EeOAbOpuPpv3gw" type="3010" element="_pDZVcFI3EeOAbOpuPpv3gw">
+                    <layoutConstraint xmi:type="notation:Location" xmi:id="_pDpNEVI3EeOAbOpuPpv3gw"/>
+                  </children>
+                  <styles xmi:type="notation:SortingStyle" xmi:id="_pDn-8lI3EeOAbOpuPpv3gw"/>
+                  <styles xmi:type="notation:FilteringStyle" xmi:id="_pDn-81I3EeOAbOpuPpv3gw"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_pDmJwVI3EeOAbOpuPpv3gw" fontName="Sans" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_pDmJwlI3EeOAbOpuPpv3gw" x="25" y="29" width="208" height="68"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_sKhecFI3EeOAbOpuPpv3gw" type="3009" element="_sJ7okFI3EeOAbOpuPpv3gw">
+                <children xmi:type="notation:Node" xmi:id="_sKiFgFI3EeOAbOpuPpv3gw" type="5004"/>
+                <children xmi:type="notation:Node" xmi:id="_sKiskFI3EeOAbOpuPpv3gw" type="7003">
+                  <children xmi:type="notation:Node" xmi:id="_usP0UFI3EeOAbOpuPpv3gw" type="3010" element="_urrMkFI3EeOAbOpuPpv3gw">
+                    <layoutConstraint xmi:type="notation:Location" xmi:id="_usP0UVI3EeOAbOpuPpv3gw"/>
+                  </children>
+                  <children xmi:type="notation:Node" xmi:id="_wduZAFI3EeOAbOpuPpv3gw" type="3010" element="_wdAnUFI3EeOAbOpuPpv3gw">
+                    <layoutConstraint xmi:type="notation:Location" xmi:id="_wduZAVI3EeOAbOpuPpv3gw"/>
+                  </children>
+                  <styles xmi:type="notation:SortingStyle" xmi:id="_sKiskVI3EeOAbOpuPpv3gw"/>
+                  <styles xmi:type="notation:FilteringStyle" xmi:id="_sKisklI3EeOAbOpuPpv3gw"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_sKhecVI3EeOAbOpuPpv3gw" fontName="Sans" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_sKheclI3EeOAbOpuPpv3gw" x="80" y="124" width="178" height="73"/>
+              </children>
+              <styles xmi:type="notation:SortingStyle" xmi:id="_dOtmclI3EeOAbOpuPpv3gw"/>
+              <styles xmi:type="notation:FilteringStyle" xmi:id="_dOtmc1I3EeOAbOpuPpv3gw"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_dOsYUVI3EeOAbOpuPpv3gw" fontName="Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dOsYUlI3EeOAbOpuPpv3gw" x="115" y="40" width="583" height="213"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_ewBoMFI3EeOAbOpuPpv3gw" type="2002" element="_evgq0FI3EeOAbOpuPpv3gw">
+            <children xmi:type="notation:Node" xmi:id="_ewC2UFI3EeOAbOpuPpv3gw" type="5006"/>
+            <children xmi:type="notation:Node" xmi:id="_ewC2UVI3EeOAbOpuPpv3gw" type="7001">
+              <children xmi:type="notation:Node" xmi:id="_9WaisFI3EeOAbOpuPpv3gw" type="3009" element="_9VsJ8FI3EeOAbOpuPpv3gw">
+                <children xmi:type="notation:Node" xmi:id="_9Wbw0FI3EeOAbOpuPpv3gw" type="5004"/>
+                <children xmi:type="notation:Node" xmi:id="_9Wbw0VI3EeOAbOpuPpv3gw" type="7003">
+                  <styles xmi:type="notation:SortingStyle" xmi:id="_9Wbw0lI3EeOAbOpuPpv3gw"/>
+                  <styles xmi:type="notation:FilteringStyle" xmi:id="_9Wbw01I3EeOAbOpuPpv3gw"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_9WaisVI3EeOAbOpuPpv3gw" fontName="Sans" fontHeight="8"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9WaislI3EeOAbOpuPpv3gw" x="55" y="42" width="133" height="55"/>
+              </children>
+              <styles xmi:type="notation:SortingStyle" xmi:id="_ewC2UlI3EeOAbOpuPpv3gw"/>
+              <styles xmi:type="notation:FilteringStyle" xmi:id="_ewC2U1I3EeOAbOpuPpv3gw"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_ewBoMVI3EeOAbOpuPpv3gw" fontName="Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ewBoMlI3EeOAbOpuPpv3gw" x="115" y="265" width="263" height="123"/>
+          </children>
+          <styles xmi:type="notation:DiagramStyle" xmi:id="_cWwDslI3EeOAbOpuPpv3gw"/>
+          <edges xmi:type="notation:Edge" xmi:id="_4feB4FI3EeOAbOpuPpv3gw" type="4001" element="_4eejYFI3EeOAbOpuPpv3gw" source="_2Bj1AFI3EeOAbOpuPpv3gw" target="_sKhecFI3EeOAbOpuPpv3gw">
+            <children xmi:type="notation:Node" xmi:id="_4fgeIFI3EeOAbOpuPpv3gw" type="6001">
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4fhFMFI3EeOAbOpuPpv3gw" y="-10"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_4fhsQFI3EeOAbOpuPpv3gw" type="6002">
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4fhsQVI3EeOAbOpuPpv3gw" y="10"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_4fi6YFI3EeOAbOpuPpv3gw" type="6003">
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4fi6YVI3EeOAbOpuPpv3gw" y="10"/>
+            </children>
+            <styles xmi:type="notation:ConnectorStyle" xmi:id="_4feo8FI3EeOAbOpuPpv3gw"/>
+            <styles xmi:type="notation:FontStyle" xmi:id="_4feo8VI3EeOAbOpuPpv3gw" fontName="Sans"/>
+            <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_4feo8lI3EeOAbOpuPpv3gw" points="[-26, 4, 114, 1]$[-138, -14, 2, -17]"/>
+            <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4fkvkFI3EeOAbOpuPpv3gw" id="(0.1956521739130435,0.5294117647058824)"/>
+            <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_4fkvkVI3EeOAbOpuPpv3gw" id="(0.8314606741573034,0.2465753424657534)"/>
+          </edges>
+          <edges xmi:type="notation:Edge" xmi:id="_A2mr8FI4EeOAbOpuPpv3gw" type="4001" element="_A19ywFI4EeOAbOpuPpv3gw" source="_9WaisFI3EeOAbOpuPpv3gw" target="_2Bj1AFI3EeOAbOpuPpv3gw">
+            <children xmi:type="notation:Node" xmi:id="_A2nTAFI4EeOAbOpuPpv3gw" type="6001">
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_A2nTAVI4EeOAbOpuPpv3gw" x="23" y="38"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_A2n6EFI4EeOAbOpuPpv3gw" type="6002">
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_A2n6EVI4EeOAbOpuPpv3gw" y="10"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_A2n6ElI4EeOAbOpuPpv3gw" type="6003">
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_A2n6E1I4EeOAbOpuPpv3gw" y="10"/>
+            </children>
+            <styles xmi:type="notation:ConnectorStyle" xmi:id="_A2mr8VI4EeOAbOpuPpv3gw"/>
+            <styles xmi:type="notation:FontStyle" xmi:id="_A2mr8lI4EeOAbOpuPpv3gw" fontName="Sans"/>
+            <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_A2mr81I4EeOAbOpuPpv3gw" points="[38, -21, -262, 151]$[248, -139, -52, 33]"/>
+            <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_A2ohIFI4EeOAbOpuPpv3gw" id="(0.7142857142857143,0.8)"/>
+          </edges>
+          <edges xmi:type="notation:Edge" xmi:id="_EjDvkFI4EeOAbOpuPpv3gw" type="4001" element="_EiaPUFI4EeOAbOpuPpv3gw" source="_9WaisFI3EeOAbOpuPpv3gw" target="_sKhecFI3EeOAbOpuPpv3gw">
+            <children xmi:type="notation:Node" xmi:id="_EjE9sFI4EeOAbOpuPpv3gw" type="6001">
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EjE9sVI4EeOAbOpuPpv3gw" y="-10"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_EjE9slI4EeOAbOpuPpv3gw" type="6002">
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EjE9s1I4EeOAbOpuPpv3gw" y="10"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_EjE9tFI4EeOAbOpuPpv3gw" type="6003">
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EjE9tVI4EeOAbOpuPpv3gw" y="10"/>
+            </children>
+            <styles xmi:type="notation:ConnectorStyle" xmi:id="_EjDvkVI4EeOAbOpuPpv3gw"/>
+            <styles xmi:type="notation:FontStyle" xmi:id="_EjDvklI4EeOAbOpuPpv3gw" fontName="Sans"/>
+            <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_EjDvk1I4EeOAbOpuPpv3gw" points="[-43, -26, -33, 126]$[-105, -64, -95, 88]$[-40, -124, -30, 28]"/>
+            <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_EjFkwFI4EeOAbOpuPpv3gw" id="(0.17415730337078653,0.2465753424657534)"/>
+          </edges>
+        </data>
+      </ownedAnnotationEntries>
+      <ownedDiagramElements xmi:type="viewpoint:DNodeContainer" xmi:id="_dOMpEFI3EeOAbOpuPpv3gw" name="Category_1">
+        <target xmi:type="org.obeonetwork.dsl.soa:Category" href="My.ois#_dOIXoFI3EeOAbOpuPpv3gw"/>
+        <semanticElements xmi:type="org.obeonetwork.dsl.soa:Category" href="My.ois#_dOIXoFI3EeOAbOpuPpv3gw"/>
+        <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+        <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+        <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+        <ownedStyle xmi:type="viewpoint:FlatContainerStyle" xmi:id="_dONQIFI3EeOAbOpuPpv3gw" backgroundStyle="GradientTopToBottom">
+          <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_dONQIVI3EeOAbOpuPpv3gw"/>
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='DTO%20View']/@defaultLayer/@containerMappings[name='DT_Category_CM']/@style"/>
+          <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_dONQIlI3EeOAbOpuPpv3gw" red="136" green="136" blue="136"/>
+          <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_dONQI1I3EeOAbOpuPpv3gw" red="209" green="209" blue="209"/>
+          <foregroundColor xmi:type="viewpoint:RGBValues" xmi:id="_dONQJFI3EeOAbOpuPpv3gw" red="255" green="255" blue="255"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description:ContainerMappingImport" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='DTO%20View']/@optionalLayers[name='DTO']/@containerMappings[name='DT_Category_CM_Import']"/>
+        <ownedDiagramElements xmi:type="viewpoint:DNodeContainer" xmi:id="_gTzIEFI3EeOAbOpuPpv3gw" name="SubCategory_1">
+          <target xmi:type="org.obeonetwork.dsl.soa:Category" href="My.ois#_gTxS4FI3EeOAbOpuPpv3gw"/>
+          <semanticElements xmi:type="org.obeonetwork.dsl.soa:Category" href="My.ois#_gTxS4FI3EeOAbOpuPpv3gw"/>
+          <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+          <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+          <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+          <ownedStyle xmi:type="viewpoint:FlatContainerStyle" xmi:id="_gT0WMFI3EeOAbOpuPpv3gw" backgroundStyle="GradientTopToBottom">
+            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_gT0WMVI3EeOAbOpuPpv3gw"/>
+            <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='DTO%20View']/@defaultLayer/@containerMappings[name='DT_Category_CM']/@style"/>
+            <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_gT0WMlI3EeOAbOpuPpv3gw" red="136" green="136" blue="136"/>
+            <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_gT0WM1I3EeOAbOpuPpv3gw" red="209" green="209" blue="209"/>
+            <foregroundColor xmi:type="viewpoint:RGBValues" xmi:id="_gT0WNFI3EeOAbOpuPpv3gw" red="255" green="255" blue="255"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description:ContainerMappingImport" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='DTO%20View']/@optionalLayers[name='DTO']/@containerMappings[name='DT_Category_CM_Import']"/>
+          <ownedDiagramElements xmi:type="viewpoint:DNodeList" xmi:id="_2A8xAFI3EeOAbOpuPpv3gw" name="BasicExtDTO" outgoingEdges="_4eejYFI3EeOAbOpuPpv3gw" incomingEdges="_A19ywFI4EeOAbOpuPpv3gw">
+            <target xmi:type="org.obeonetwork.dsl.soa:ServiceDTO" href="My.ois#_2A670FI3EeOAbOpuPpv3gw"/>
+            <semanticElements xmi:type="org.obeonetwork.dsl.soa:ServiceDTO" href="My.ois#_2A670FI3EeOAbOpuPpv3gw"/>
+            <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+            <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+            <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+            <ownedStyle xmi:type="viewpoint:FlatContainerStyle" xmi:id="_2A9_IFI3EeOAbOpuPpv3gw" backgroundStyle="GradientTopToBottom">
+              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_2A9_IVI3EeOAbOpuPpv3gw"/>
+              <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='DTO%20View']/@optionalLayers[name='DTO']/@containerMappings[name='DT_Category_CM_Import']/@subContainerMappings[name='DT_ServiceDTO_CM']/@style"/>
+              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_2A9_IlI3EeOAbOpuPpv3gw" red="214" green="197" blue="66"/>
+              <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_2A9_I1I3EeOAbOpuPpv3gw" red="255" green="245" blue="181"/>
+              <foregroundColor xmi:type="viewpoint:RGBValues" xmi:id="_2A9_JFI3EeOAbOpuPpv3gw" red="255" green="255" blue="255"/>
+            </ownedStyle>
+            <actualMapping xmi:type="description:ContainerMapping" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='DTO%20View']/@optionalLayers[name='DTO']/@containerMappings[name='DT_Category_CM_Import']/@subContainerMappings[name='DT_ServiceDTO_CM']"/>
+            <ownedElements xmi:type="viewpoint:DNodeListElement" xmi:id="_6hQTcFI3EeOAbOpuPpv3gw" name="qix : String[0..*]">
+              <target xmi:type="oenv:Attribute" href="My.ois#_6hN3MFI3EeOAbOpuPpv3gw"/>
+              <semanticElements xmi:type="oenv:Attribute" href="My.ois#_6hN3MFI3EeOAbOpuPpv3gw"/>
+              <ownedStyle xmi:type="viewpoint:Square" xmi:id="_6hQTcVI3EeOAbOpuPpv3gw" labelAlignment="LEFT">
+                <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_6hQTclI3EeOAbOpuPpv3gw"/>
+                <description xmi:type="style:SquareDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='DTO%20View']/@optionalLayers[name='DTO']/@containerMappings[name='DT_Category_CM_Import']/@subContainerMappings[name='DT_ServiceDTO_CM']/@subNodeMappings[name='DT_Attribute_NM']/@style"/>
+                <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_6hQTc1I3EeOAbOpuPpv3gw"/>
+                <color xmi:type="viewpoint:RGBValues" xmi:id="_6hQTdFI3EeOAbOpuPpv3gw" red="136" green="136" blue="136"/>
+              </ownedStyle>
+              <actualMapping xmi:type="description:NodeMapping" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='DTO%20View']/@optionalLayers[name='DTO']/@containerMappings[name='DT_Category_CM_Import']/@subContainerMappings[name='DT_ServiceDTO_CM']/@subNodeMappings[name='DT_Attribute_NM']"/>
+            </ownedElements>
+          </ownedDiagramElements>
+        </ownedDiagramElements>
+        <ownedDiagramElements xmi:type="viewpoint:DNodeList" xmi:id="_pDTO0FI3EeOAbOpuPpv3gw" name="Entity_1DTO > Entity_1">
+          <target xmi:type="org.obeonetwork.dsl.soa:ServiceDTO" href="My.ois#_pCjA4FI3EeOAbOpuPpv3gw"/>
+          <semanticElements xmi:type="org.obeonetwork.dsl.soa:ServiceDTO" href="My.ois#_pCjA4FI3EeOAbOpuPpv3gw"/>
+          <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+          <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+          <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+          <ownedStyle xmi:type="viewpoint:FlatContainerStyle" xmi:id="_pDWSIFI3EeOAbOpuPpv3gw" backgroundStyle="GradientTopToBottom">
+            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_pDWSIVI3EeOAbOpuPpv3gw"/>
+            <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='DTO%20View']/@optionalLayers[name='DTO']/@containerMappings[name='DT_Category_CM_Import']/@subContainerMappings[name='DT_ServiceDTO_CM']/@style"/>
+            <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_pDWSIlI3EeOAbOpuPpv3gw" red="214" green="197" blue="66"/>
+            <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_pDWSI1I3EeOAbOpuPpv3gw" red="255" green="245" blue="181"/>
+            <foregroundColor xmi:type="viewpoint:RGBValues" xmi:id="_pDWSJFI3EeOAbOpuPpv3gw" red="255" green="255" blue="255"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description:ContainerMapping" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='DTO%20View']/@optionalLayers[name='DTO']/@containerMappings[name='DT_Category_CM_Import']/@subContainerMappings[name='DT_ServiceDTO_CM']"/>
+          <ownedElements xmi:type="viewpoint:DNodeListElement" xmi:id="_pDXgQFI3EeOAbOpuPpv3gw" name="&lt;inherited> attribute1 : String[0..1]">
+            <target xmi:type="oent:Attribute" href="My.ois#_kEVP4FI2EeOAbOpuPpv3gw"/>
+            <semanticElements xmi:type="oent:Attribute" href="My.ois#_kEVP4FI2EeOAbOpuPpv3gw"/>
+            <ownedStyle xmi:type="viewpoint:Square" xmi:id="_pDYHUFI3EeOAbOpuPpv3gw" labelFormat="italic" labelAlignment="LEFT">
+              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_pDYHUVI3EeOAbOpuPpv3gw"/>
+              <description xmi:type="style:SquareDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='DTO%20View']/@optionalLayers[name='DTO']/@containerMappings[name='DT_Category_CM_Import']/@subContainerMappings[name='DT_ServiceDTO_CM']/@subNodeMappings[name='DT_AssociatedAttribute_NM']/@style"/>
+              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_pDYuYFI3EeOAbOpuPpv3gw"/>
+              <color xmi:type="viewpoint:RGBValues" xmi:id="_pDYuYVI3EeOAbOpuPpv3gw" red="114" green="159" blue="207"/>
+            </ownedStyle>
+            <actualMapping xmi:type="description:NodeMapping" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='DTO%20View']/@optionalLayers[name='DTO']/@containerMappings[name='DT_Category_CM_Import']/@subContainerMappings[name='DT_ServiceDTO_CM']/@subNodeMappings[name='DT_AssociatedAttribute_NM']"/>
+          </ownedElements>
+          <ownedElements xmi:type="viewpoint:DNodeListElement" xmi:id="_pDZVcFI3EeOAbOpuPpv3gw" name="&lt;inherited> attribute2 : Integer[1]">
+            <target xmi:type="oent:Attribute" href="My.ois#_qRfVsFI2EeOAbOpuPpv3gw"/>
+            <semanticElements xmi:type="oent:Attribute" href="My.ois#_qRfVsFI2EeOAbOpuPpv3gw"/>
+            <ownedStyle xmi:type="viewpoint:Square" xmi:id="_pDZ8gFI3EeOAbOpuPpv3gw" labelFormat="italic" labelAlignment="LEFT">
+              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_pDZ8gVI3EeOAbOpuPpv3gw"/>
+              <description xmi:type="style:SquareDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='DTO%20View']/@optionalLayers[name='DTO']/@containerMappings[name='DT_Category_CM_Import']/@subContainerMappings[name='DT_ServiceDTO_CM']/@subNodeMappings[name='DT_AssociatedAttribute_NM']/@style"/>
+              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_pDZ8glI3EeOAbOpuPpv3gw"/>
+              <color xmi:type="viewpoint:RGBValues" xmi:id="_pDajkFI3EeOAbOpuPpv3gw" red="114" green="159" blue="207"/>
+            </ownedStyle>
+            <actualMapping xmi:type="description:NodeMapping" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='DTO%20View']/@optionalLayers[name='DTO']/@containerMappings[name='DT_Category_CM_Import']/@subContainerMappings[name='DT_ServiceDTO_CM']/@subNodeMappings[name='DT_AssociatedAttribute_NM']"/>
+          </ownedElements>
+        </ownedDiagramElements>
+        <ownedDiagramElements xmi:type="viewpoint:DNodeList" xmi:id="_sJ7okFI3EeOAbOpuPpv3gw" name="BasicDTO" incomingEdges="_4eejYFI3EeOAbOpuPpv3gw _EiaPUFI4EeOAbOpuPpv3gw">
+          <target xmi:type="org.obeonetwork.dsl.soa:ServiceDTO" href="My.ois#_sJ5MUFI3EeOAbOpuPpv3gw"/>
+          <semanticElements xmi:type="org.obeonetwork.dsl.soa:ServiceDTO" href="My.ois#_sJ5MUFI3EeOAbOpuPpv3gw"/>
+          <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+          <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+          <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+          <ownedStyle xmi:type="viewpoint:FlatContainerStyle" xmi:id="_sJ8PoFI3EeOAbOpuPpv3gw" backgroundStyle="GradientTopToBottom">
+            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_sJ8PoVI3EeOAbOpuPpv3gw"/>
+            <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='DTO%20View']/@optionalLayers[name='DTO']/@containerMappings[name='DT_Category_CM_Import']/@subContainerMappings[name='DT_ServiceDTO_CM']/@style"/>
+            <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_sJ8PolI3EeOAbOpuPpv3gw" red="214" green="197" blue="66"/>
+            <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_sJ8Po1I3EeOAbOpuPpv3gw" red="255" green="245" blue="181"/>
+            <foregroundColor xmi:type="viewpoint:RGBValues" xmi:id="_sJ8PpFI3EeOAbOpuPpv3gw" red="255" green="255" blue="255"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description:ContainerMapping" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='DTO%20View']/@optionalLayers[name='DTO']/@containerMappings[name='DT_Category_CM_Import']/@subContainerMappings[name='DT_ServiceDTO_CM']"/>
+          <ownedElements xmi:type="viewpoint:DNodeListElement" xmi:id="_urrMkFI3EeOAbOpuPpv3gw" name="foo : String[0..1]">
+            <target xmi:type="oenv:Attribute" href="My.ois#_urRj8FI3EeOAbOpuPpv3gw"/>
+            <semanticElements xmi:type="oenv:Attribute" href="My.ois#_urRj8FI3EeOAbOpuPpv3gw"/>
+            <ownedStyle xmi:type="viewpoint:Square" xmi:id="_urrMkVI3EeOAbOpuPpv3gw" labelAlignment="LEFT">
+              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_urrMklI3EeOAbOpuPpv3gw"/>
+              <description xmi:type="style:SquareDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='DTO%20View']/@optionalLayers[name='DTO']/@containerMappings[name='DT_Category_CM_Import']/@subContainerMappings[name='DT_ServiceDTO_CM']/@subNodeMappings[name='DT_Attribute_NM']/@style"/>
+              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_urrMk1I3EeOAbOpuPpv3gw"/>
+              <color xmi:type="viewpoint:RGBValues" xmi:id="_urrMlFI3EeOAbOpuPpv3gw" red="136" green="136" blue="136"/>
+            </ownedStyle>
+            <actualMapping xmi:type="description:NodeMapping" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='DTO%20View']/@optionalLayers[name='DTO']/@containerMappings[name='DT_Category_CM_Import']/@subContainerMappings[name='DT_ServiceDTO_CM']/@subNodeMappings[name='DT_Attribute_NM']"/>
+          </ownedElements>
+          <ownedElements xmi:type="viewpoint:DNodeListElement" xmi:id="_wdAnUFI3EeOAbOpuPpv3gw" name="bar : Date[1]">
+            <target xmi:type="oenv:Attribute" href="My.ois#_wc-yIFI3EeOAbOpuPpv3gw"/>
+            <semanticElements xmi:type="oenv:Attribute" href="My.ois#_wc-yIFI3EeOAbOpuPpv3gw"/>
+            <ownedStyle xmi:type="viewpoint:Square" xmi:id="_wdAnUVI3EeOAbOpuPpv3gw" labelAlignment="LEFT">
+              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_wdBOYFI3EeOAbOpuPpv3gw"/>
+              <description xmi:type="style:SquareDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='DTO%20View']/@optionalLayers[name='DTO']/@containerMappings[name='DT_Category_CM_Import']/@subContainerMappings[name='DT_ServiceDTO_CM']/@subNodeMappings[name='DT_Attribute_NM']/@style"/>
+              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_wdBOYVI3EeOAbOpuPpv3gw"/>
+              <color xmi:type="viewpoint:RGBValues" xmi:id="_wdBOYlI3EeOAbOpuPpv3gw" red="136" green="136" blue="136"/>
+            </ownedStyle>
+            <actualMapping xmi:type="description:NodeMapping" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='DTO%20View']/@optionalLayers[name='DTO']/@containerMappings[name='DT_Category_CM_Import']/@subContainerMappings[name='DT_ServiceDTO_CM']/@subNodeMappings[name='DT_Attribute_NM']"/>
+          </ownedElements>
+        </ownedDiagramElements>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="viewpoint:DNodeContainer" xmi:id="_evgq0FI3EeOAbOpuPpv3gw" name="Category_2">
+        <target xmi:type="org.obeonetwork.dsl.soa:Category" href="My.ois#_eveOkFI3EeOAbOpuPpv3gw"/>
+        <semanticElements xmi:type="org.obeonetwork.dsl.soa:Category" href="My.ois#_eveOkFI3EeOAbOpuPpv3gw"/>
+        <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+        <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+        <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+        <ownedStyle xmi:type="viewpoint:FlatContainerStyle" xmi:id="_evhR4FI3EeOAbOpuPpv3gw" backgroundStyle="GradientTopToBottom">
+          <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_evhR4VI3EeOAbOpuPpv3gw"/>
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='DTO%20View']/@defaultLayer/@containerMappings[name='DT_Category_CM']/@style"/>
+          <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_evhR4lI3EeOAbOpuPpv3gw" red="136" green="136" blue="136"/>
+          <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_evhR41I3EeOAbOpuPpv3gw" red="209" green="209" blue="209"/>
+          <foregroundColor xmi:type="viewpoint:RGBValues" xmi:id="_evhR5FI3EeOAbOpuPpv3gw" red="255" green="255" blue="255"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description:ContainerMappingImport" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='DTO%20View']/@optionalLayers[name='DTO']/@containerMappings[name='DT_Category_CM_Import']"/>
+        <ownedDiagramElements xmi:type="viewpoint:DNodeList" xmi:id="_9VsJ8FI3EeOAbOpuPpv3gw" name="CompositeDTO" outgoingEdges="_A19ywFI4EeOAbOpuPpv3gw _EiaPUFI4EeOAbOpuPpv3gw">
+          <target xmi:type="org.obeonetwork.dsl.soa:ServiceDTO" href="My.ois#_9VqUwFI3EeOAbOpuPpv3gw"/>
+          <semanticElements xmi:type="org.obeonetwork.dsl.soa:ServiceDTO" href="My.ois#_9VqUwFI3EeOAbOpuPpv3gw"/>
+          <ownedStyle xmi:type="viewpoint:FlatContainerStyle" xmi:id="_9VsxAFI3EeOAbOpuPpv3gw" backgroundStyle="GradientTopToBottom">
+            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_9VsxAVI3EeOAbOpuPpv3gw"/>
+            <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='DTO%20View']/@optionalLayers[name='DTO']/@containerMappings[name='DT_Category_CM_Import']/@subContainerMappings[name='DT_ServiceDTO_CM']/@style"/>
+            <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_9VsxAlI3EeOAbOpuPpv3gw" red="214" green="197" blue="66"/>
+            <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_9VsxA1I3EeOAbOpuPpv3gw" red="255" green="245" blue="181"/>
+            <foregroundColor xmi:type="viewpoint:RGBValues" xmi:id="_9VsxBFI3EeOAbOpuPpv3gw" red="255" green="255" blue="255"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description:ContainerMapping" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='DTO%20View']/@optionalLayers[name='DTO']/@containerMappings[name='DT_Category_CM_Import']/@subContainerMappings[name='DT_ServiceDTO_CM']"/>
+        </ownedDiagramElements>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="viewpoint:DEdge" xmi:id="_4eejYFI3EeOAbOpuPpv3gw" sourceNode="_2A8xAFI3EeOAbOpuPpv3gw" targetNode="_sJ7okFI3EeOAbOpuPpv3gw">
+        <target xmi:type="org.obeonetwork.dsl.soa:ServiceDTO" href="My.ois#_2A670FI3EeOAbOpuPpv3gw"/>
+        <ownedStyle xmi:type="viewpoint:EdgeStyle" xmi:id="_4eg_oFI3EeOAbOpuPpv3gw" targetArrow="InputClosedArrow">
+          <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='DTO%20View']/@optionalLayers[name='DTO']/@edgeMappings[name='DT_Inheritance_ServiceDTO_ServiceDTO']/@style"/>
+          <strokeColor xmi:type="viewpoint:RGBValues" xmi:id="_4eg_oVI3EeOAbOpuPpv3gw" red="136" green="136" blue="136"/>
+          <centerLabelStyle xmi:type="viewpoint:CenterLabelStyle" xmi:id="_4eg_olI3EeOAbOpuPpv3gw">
+            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_4eg_o1I3EeOAbOpuPpv3gw"/>
+          </centerLabelStyle>
+        </ownedStyle>
+        <actualMapping xmi:type="description:EdgeMapping" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='DTO%20View']/@optionalLayers[name='DTO']/@edgeMappings[name='DT_Inheritance_ServiceDTO_ServiceDTO']"/>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="viewpoint:DEdge" xmi:id="_A19ywFI4EeOAbOpuPpv3gw" name="basicExt [0..1]" sourceNode="_9VsJ8FI3EeOAbOpuPpv3gw" targetNode="_2A8xAFI3EeOAbOpuPpv3gw">
+        <target xmi:type="oenv:Reference" href="My.ois#_A15hUFI4EeOAbOpuPpv3gw"/>
+        <semanticElements xmi:type="oenv:Reference" href="My.ois#_A15hUFI4EeOAbOpuPpv3gw"/>
+        <ownedStyle xmi:type="viewpoint:EdgeStyle" xmi:id="_A1-Z0FI4EeOAbOpuPpv3gw" sourceArrow="Diamond">
+          <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='DTO%20View']/@optionalLayers[name='DTO']/@edgeMappings[name='DT_Reference_ServiceDTO_ServiceDTO']/@conditionnalStyles.0/@style"/>
+          <strokeColor xmi:type="viewpoint:RGBValues" xmi:id="_A1-Z0VI4EeOAbOpuPpv3gw" red="136" green="136" blue="136"/>
+          <centerLabelStyle xmi:type="viewpoint:CenterLabelStyle" xmi:id="_A1-Z0lI4EeOAbOpuPpv3gw" showIcon="false">
+            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_A1-Z01I4EeOAbOpuPpv3gw"/>
+          </centerLabelStyle>
+        </ownedStyle>
+        <actualMapping xmi:type="description:EdgeMapping" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='DTO%20View']/@optionalLayers[name='DTO']/@edgeMappings[name='DT_Reference_ServiceDTO_ServiceDTO']"/>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="viewpoint:DEdge" xmi:id="_EiaPUFI4EeOAbOpuPpv3gw" name="basic [0..*]" sourceNode="_9VsJ8FI3EeOAbOpuPpv3gw" targetNode="_sJ7okFI3EeOAbOpuPpv3gw">
+        <target xmi:type="oenv:Reference" href="My.ois#_EiUvwFI4EeOAbOpuPpv3gw"/>
+        <semanticElements xmi:type="oenv:Reference" href="My.ois#_EiUvwFI4EeOAbOpuPpv3gw"/>
+        <ownedStyle xmi:type="viewpoint:EdgeStyle" xmi:id="_EibdcFI4EeOAbOpuPpv3gw">
+          <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='DTO%20View']/@optionalLayers[name='DTO']/@edgeMappings[name='DT_Reference_ServiceDTO_ServiceDTO']/@conditionnalStyles.1/@style"/>
+          <strokeColor xmi:type="viewpoint:RGBValues" xmi:id="_EibdcVI4EeOAbOpuPpv3gw" red="136" green="136" blue="136"/>
+          <centerLabelStyle xmi:type="viewpoint:CenterLabelStyle" xmi:id="_EibdclI4EeOAbOpuPpv3gw" showIcon="false">
+            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_Eibdc1I4EeOAbOpuPpv3gw"/>
+          </centerLabelStyle>
+        </ownedStyle>
+        <actualMapping xmi:type="description:EdgeMapping" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='DTO%20View']/@optionalLayers[name='DTO']/@edgeMappings[name='DT_Reference_ServiceDTO_ServiceDTO']"/>
+      </ownedDiagramElements>
+      <description xmi:type="description:DiagramDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='DTO%20View']"/>
+      <filterVariableHistory xmi:type="viewpoint:FilterVariableHistory" xmi:id="_cWoH4VI3EeOAbOpuPpv3gw"/>
+      <activatedLayers xmi:type="description:Layer" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='DTO%20View']/@defaultLayer"/>
+      <activatedLayers xmi:type="description:OptionalLayer" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='DTO%20View']/@optionalLayers[name='DTO']"/>
+      <target xmi:type="org.obeonetwork.dsl.soa:DTORegistry" href="My.ois#_E5KX4FI3EeOAbOpuPpv3gw"/>
+    </ownedRepresentations>
+    <ownedRepresentations xmi:type="viewpoint:DSemanticDiagram" xmi:id="_Klo9EFI4EeOAbOpuPpv3gw" name="Component_1 Component Contract">
+      <ownedAnnotationEntries xmi:type="description:AnnotationEntry" xmi:id="_Kl1KUFI4EeOAbOpuPpv3gw" source="GMF_DIAGRAMS">
+        <data xmi:type="notation:Diagram" xmi:id="_Kl1KUVI4EeOAbOpuPpv3gw" type="Viewpoint" element="_Klo9EFI4EeOAbOpuPpv3gw" measurementUnit="Pixel">
+          <children xmi:type="notation:Node" xmi:id="_KmeqkFI4EeOAbOpuPpv3gw" type="2002" element="_KmcOUFI4EeOAbOpuPpv3gw">
+            <children xmi:type="notation:Node" xmi:id="_Kmf4sFI4EeOAbOpuPpv3gw" type="5006"/>
+            <children xmi:type="notation:Node" xmi:id="_Kmf4sVI4EeOAbOpuPpv3gw" type="7001">
+              <children xmi:type="notation:Node" xmi:id="_MDrBUFI4EeOAbOpuPpv3gw" type="3009" element="_MC3JAFI4EeOAbOpuPpv3gw">
+                <children xmi:type="notation:Node" xmi:id="_MDroYFI4EeOAbOpuPpv3gw" type="5004"/>
+                <children xmi:type="notation:Node" xmi:id="_MDsPcFI4EeOAbOpuPpv3gw" type="7003">
+                  <children xmi:type="notation:Node" xmi:id="_TIUIwFI4EeOAbOpuPpv3gw" type="3010" element="_THd0MFI4EeOAbOpuPpv3gw">
+                    <layoutConstraint xmi:type="notation:Location" xmi:id="_TIUIwVI4EeOAbOpuPpv3gw"/>
+                  </children>
+                  <children xmi:type="notation:Node" xmi:id="_hudSwFI4EeOAbOpuPpv3gw" type="3010" element="_ht1AoFI4EeOAbOpuPpv3gw">
+                    <layoutConstraint xmi:type="notation:Location" xmi:id="_hudSwVI4EeOAbOpuPpv3gw"/>
+                  </children>
+                  <children xmi:type="notation:Node" xmi:id="_sKVbwFI4EeOAbOpuPpv3gw" type="3010" element="_sJu-0FI4EeOAbOpuPpv3gw">
+                    <layoutConstraint xmi:type="notation:Location" xmi:id="_sKVbwVI4EeOAbOpuPpv3gw"/>
+                  </children>
+                  <children xmi:type="notation:Node" xmi:id="_9xCzwFI4EeOAbOpuPpv3gw" type="3010" element="_9wL4IFI4EeOAbOpuPpv3gw">
+                    <layoutConstraint xmi:type="notation:Location" xmi:id="_9xCzwVI4EeOAbOpuPpv3gw"/>
+                  </children>
+                  <styles xmi:type="notation:SortingStyle" xmi:id="_MDsPcVI4EeOAbOpuPpv3gw"/>
+                  <styles xmi:type="notation:FilteringStyle" xmi:id="_MDsPclI4EeOAbOpuPpv3gw"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_MDrBUVI4EeOAbOpuPpv3gw" fontName="Sans" fontHeight="10"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_MDrBUlI4EeOAbOpuPpv3gw" x="45" y="49" width="203" height="133"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_NfNLMFI4EeOAbOpuPpv3gw" type="3009" element="_NeUaYFI4EeOAbOpuPpv3gw">
+                <children xmi:type="notation:Node" xmi:id="_NfOZUFI4EeOAbOpuPpv3gw" type="5004"/>
+                <children xmi:type="notation:Node" xmi:id="_NfOZUVI4EeOAbOpuPpv3gw" type="7003">
+                  <children xmi:type="notation:Node" xmi:id="_0tB1kFI4EeOAbOpuPpv3gw" type="3010" element="_0r07sFI4EeOAbOpuPpv3gw">
+                    <layoutConstraint xmi:type="notation:Location" xmi:id="_0tB1kVI4EeOAbOpuPpv3gw"/>
+                  </children>
+                  <styles xmi:type="notation:SortingStyle" xmi:id="_NfOZUlI4EeOAbOpuPpv3gw"/>
+                  <styles xmi:type="notation:FilteringStyle" xmi:id="_NfOZU1I4EeOAbOpuPpv3gw"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_NfNLMVI4EeOAbOpuPpv3gw" fontName="Sans" fontHeight="10"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NfNLMlI4EeOAbOpuPpv3gw" x="45" y="204" width="203" height="83"/>
+              </children>
+              <styles xmi:type="notation:SortingStyle" xmi:id="_Kmf4slI4EeOAbOpuPpv3gw"/>
+              <styles xmi:type="notation:FilteringStyle" xmi:id="_Kmf4s1I4EeOAbOpuPpv3gw"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_KmeqkVI4EeOAbOpuPpv3gw" fontName="Sans" fontHeight="10"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_KmeqklI4EeOAbOpuPpv3gw" x="110" y="45" width="293" height="328"/>
+          </children>
+          <styles xmi:type="notation:DiagramStyle" xmi:id="_Kl1KUlI4EeOAbOpuPpv3gw"/>
+        </data>
+      </ownedAnnotationEntries>
+      <ownedDiagramElements xmi:type="viewpoint:DNodeContainer" xmi:id="_KmcOUFI4EeOAbOpuPpv3gw" name="ProvidedService1">
+        <target xmi:type="org.obeonetwork.dsl.soa:Service" href="My.ois#_ZwhoUFI3EeOAbOpuPpv3gw"/>
+        <semanticElements xmi:type="org.obeonetwork.dsl.soa:Service" href="My.ois#_ZwhoUFI3EeOAbOpuPpv3gw"/>
+        <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+        <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+        <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+        <ownedStyle xmi:type="viewpoint:FlatContainerStyle" xmi:id="_KmdccFI4EeOAbOpuPpv3gw" labelSize="10" backgroundStyle="GradientTopToBottom">
+          <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_KmdccVI4EeOAbOpuPpv3gw"/>
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='Component%20Contract%20Diagram']/@defaultLayer/@containerMappings[name='Cc_ServiceInterface_CM']/@style"/>
+          <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_KmdcclI4EeOAbOpuPpv3gw" red="69" green="69" blue="69"/>
+          <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_Kmdcc1I4EeOAbOpuPpv3gw" red="255" green="255" blue="255"/>
+          <foregroundColor xmi:type="viewpoint:RGBValues" xmi:id="_KmdcdFI4EeOAbOpuPpv3gw" red="209" green="209" blue="209"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description:ContainerMapping" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='Component%20Contract%20Diagram']/@defaultLayer/@containerMappings[name='Cc_ServiceInterface_CM']"/>
+        <ownedDiagramElements xmi:type="viewpoint:DNodeList" xmi:id="_MC3JAFI4EeOAbOpuPpv3gw" name="requestResponse">
+          <target xmi:type="org.obeonetwork.dsl.soa:Operation" href="My.ois#_MC2h8FI4EeOAbOpuPpv3gw"/>
+          <semanticElements xmi:type="org.obeonetwork.dsl.soa:Operation" href="My.ois#_MC2h8FI4EeOAbOpuPpv3gw"/>
+          <ownedStyle xmi:type="viewpoint:FlatContainerStyle" xmi:id="_MC3wEFI4EeOAbOpuPpv3gw" labelSize="10">
+            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_MC3wEVI4EeOAbOpuPpv3gw"/>
+            <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='Component%20Contract%20Diagram']/@defaultLayer/@containerMappings[name='Cc_ServiceInterface_CM']/@subContainerMappings[name='Cc_Operation_CM']/@style"/>
+            <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_MC3wElI4EeOAbOpuPpv3gw" red="39" green="76" blue="114"/>
+            <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_MC3wE1I4EeOAbOpuPpv3gw" red="255" green="255" blue="255"/>
+            <foregroundColor xmi:type="viewpoint:RGBValues" xmi:id="_MC3wFFI4EeOAbOpuPpv3gw" red="209" green="209" blue="209"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description:ContainerMapping" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='Component%20Contract%20Diagram']/@defaultLayer/@containerMappings[name='Cc_ServiceInterface_CM']/@subContainerMappings[name='Cc_Operation_CM']"/>
+          <ownedElements xmi:type="viewpoint:DNodeListElement" xmi:id="_THd0MFI4EeOAbOpuPpv3gw" name="entity : Entity_1DTO[1]">
+            <target xmi:type="org.obeonetwork.dsl.soa:Parameter" href="My.ois#_THbX8FI4EeOAbOpuPpv3gw"/>
+            <semanticElements xmi:type="org.obeonetwork.dsl.soa:Parameter" href="My.ois#_THbX8FI4EeOAbOpuPpv3gw"/>
+            <ownedStyle xmi:type="viewpoint:Square" xmi:id="_THd0MVI4EeOAbOpuPpv3gw" labelAlignment="LEFT">
+              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_THd0MlI4EeOAbOpuPpv3gw"/>
+              <description xmi:type="style:SquareDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='Component%20Contract%20Diagram']/@defaultLayer/@containerMappings[name='Cc_ServiceInterface_CM']/@subContainerMappings[name='Cc_Operation_CM']/@subNodeMappings[name='Cc_In_Param']/@style"/>
+              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_THd0M1I4EeOAbOpuPpv3gw"/>
+              <color xmi:type="viewpoint:RGBValues" xmi:id="_THd0NFI4EeOAbOpuPpv3gw" red="136" green="136" blue="136"/>
+            </ownedStyle>
+            <actualMapping xmi:type="description:NodeMapping" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='Component%20Contract%20Diagram']/@defaultLayer/@containerMappings[name='Cc_ServiceInterface_CM']/@subContainerMappings[name='Cc_Operation_CM']/@subNodeMappings[name='Cc_In_Param']"/>
+          </ownedElements>
+          <ownedElements xmi:type="viewpoint:DNodeListElement" xmi:id="_ht1AoFI4EeOAbOpuPpv3gw" name="primitiveString : String[0..1]">
+            <target xmi:type="org.obeonetwork.dsl.soa:Parameter" href="My.ois#_htzLcFI4EeOAbOpuPpv3gw"/>
+            <semanticElements xmi:type="org.obeonetwork.dsl.soa:Parameter" href="My.ois#_htzLcFI4EeOAbOpuPpv3gw"/>
+            <ownedStyle xmi:type="viewpoint:Square" xmi:id="_ht1AoVI4EeOAbOpuPpv3gw" labelAlignment="LEFT">
+              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_ht1AolI4EeOAbOpuPpv3gw"/>
+              <description xmi:type="style:SquareDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='Component%20Contract%20Diagram']/@defaultLayer/@containerMappings[name='Cc_ServiceInterface_CM']/@subContainerMappings[name='Cc_Operation_CM']/@subNodeMappings[name='Cc_In_Param']/@style"/>
+              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_ht1Ao1I4EeOAbOpuPpv3gw"/>
+              <color xmi:type="viewpoint:RGBValues" xmi:id="_ht1ApFI4EeOAbOpuPpv3gw" red="136" green="136" blue="136"/>
+            </ownedStyle>
+            <actualMapping xmi:type="description:NodeMapping" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='Component%20Contract%20Diagram']/@defaultLayer/@containerMappings[name='Cc_ServiceInterface_CM']/@subContainerMappings[name='Cc_Operation_CM']/@subNodeMappings[name='Cc_In_Param']"/>
+          </ownedElements>
+          <ownedElements xmi:type="viewpoint:DNodeListElement" xmi:id="_sJu-0FI4EeOAbOpuPpv3gw" name="output1 : BasicDTO[1]">
+            <target xmi:type="org.obeonetwork.dsl.soa:Parameter" href="My.ois#_sJtJoFI4EeOAbOpuPpv3gw"/>
+            <semanticElements xmi:type="org.obeonetwork.dsl.soa:Parameter" href="My.ois#_sJtJoFI4EeOAbOpuPpv3gw"/>
+            <ownedStyle xmi:type="viewpoint:Square" xmi:id="_sJu-0VI4EeOAbOpuPpv3gw" labelFormat="italic" labelAlignment="LEFT">
+              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_sJu-0lI4EeOAbOpuPpv3gw"/>
+              <description xmi:type="style:SquareDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='Component%20Contract%20Diagram']/@defaultLayer/@containerMappings[name='Cc_ServiceInterface_CM']/@subContainerMappings[name='Cc_Operation_CM']/@subNodeMappings[name='Cc_Out_Param']/@style"/>
+              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_sJu-01I4EeOAbOpuPpv3gw"/>
+              <color xmi:type="viewpoint:RGBValues" xmi:id="_sJu-1FI4EeOAbOpuPpv3gw" red="136" green="136" blue="136"/>
+            </ownedStyle>
+            <actualMapping xmi:type="description:NodeMapping" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='Component%20Contract%20Diagram']/@defaultLayer/@containerMappings[name='Cc_ServiceInterface_CM']/@subContainerMappings[name='Cc_Operation_CM']/@subNodeMappings[name='Cc_Out_Param']"/>
+          </ownedElements>
+          <ownedElements xmi:type="viewpoint:DNodeListElement" xmi:id="_9wL4IFI4EeOAbOpuPpv3gw" name="faultString : String[1]">
+            <target xmi:type="org.obeonetwork.dsl.soa:Parameter" href="My.ois#_9wKC8FI4EeOAbOpuPpv3gw"/>
+            <semanticElements xmi:type="org.obeonetwork.dsl.soa:Parameter" href="My.ois#_9wKC8FI4EeOAbOpuPpv3gw"/>
+            <ownedStyle xmi:type="viewpoint:Square" xmi:id="_9wL4IVI4EeOAbOpuPpv3gw" labelAlignment="LEFT">
+              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_9wL4IlI4EeOAbOpuPpv3gw"/>
+              <description xmi:type="style:SquareDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='Component%20Contract%20Diagram']/@defaultLayer/@containerMappings[name='Cc_ServiceInterface_CM']/@subContainerMappings[name='Cc_Operation_CM']/@subNodeMappings[name='Cc_Fault_Param']/@style"/>
+              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_9wL4I1I4EeOAbOpuPpv3gw"/>
+              <color xmi:type="viewpoint:RGBValues" xmi:id="_9wL4JFI4EeOAbOpuPpv3gw" red="136" green="136" blue="136"/>
+            </ownedStyle>
+            <actualMapping xmi:type="description:NodeMapping" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='Component%20Contract%20Diagram']/@defaultLayer/@containerMappings[name='Cc_ServiceInterface_CM']/@subContainerMappings[name='Cc_Operation_CM']/@subNodeMappings[name='Cc_Fault_Param']"/>
+          </ownedElements>
+        </ownedDiagramElements>
+        <ownedDiagramElements xmi:type="viewpoint:DNodeList" xmi:id="_NeUaYFI4EeOAbOpuPpv3gw" name="oneWay">
+          <target xmi:type="org.obeonetwork.dsl.soa:Operation" href="My.ois#_NeTzUFI4EeOAbOpuPpv3gw"/>
+          <semanticElements xmi:type="org.obeonetwork.dsl.soa:Operation" href="My.ois#_NeTzUFI4EeOAbOpuPpv3gw"/>
+          <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+          <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+          <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+          <ownedStyle xmi:type="viewpoint:FlatContainerStyle" xmi:id="_NeVBcFI4EeOAbOpuPpv3gw" labelSize="10">
+            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_NeVBcVI4EeOAbOpuPpv3gw"/>
+            <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='Component%20Contract%20Diagram']/@defaultLayer/@containerMappings[name='Cc_ServiceInterface_CM']/@subContainerMappings[name='Cc_Operation_CM']/@style"/>
+            <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_NeVBclI4EeOAbOpuPpv3gw" red="39" green="76" blue="114"/>
+            <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_NeVBc1I4EeOAbOpuPpv3gw" red="255" green="255" blue="255"/>
+            <foregroundColor xmi:type="viewpoint:RGBValues" xmi:id="_NeVBdFI4EeOAbOpuPpv3gw" red="209" green="209" blue="209"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description:ContainerMapping" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='Component%20Contract%20Diagram']/@defaultLayer/@containerMappings[name='Cc_ServiceInterface_CM']/@subContainerMappings[name='Cc_Operation_CM']"/>
+          <ownedElements xmi:type="viewpoint:DNodeListElement" xmi:id="_0r07sFI4EeOAbOpuPpv3gw" name="composite : CompositeDTO[1]">
+            <target xmi:type="org.obeonetwork.dsl.soa:Parameter" href="My.ois#_0ryfcFI4EeOAbOpuPpv3gw"/>
+            <semanticElements xmi:type="org.obeonetwork.dsl.soa:Parameter" href="My.ois#_0ryfcFI4EeOAbOpuPpv3gw"/>
+            <ownedStyle xmi:type="viewpoint:Square" xmi:id="_0r07sVI4EeOAbOpuPpv3gw" labelAlignment="LEFT">
+              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_0r07slI4EeOAbOpuPpv3gw"/>
+              <description xmi:type="style:SquareDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='Component%20Contract%20Diagram']/@defaultLayer/@containerMappings[name='Cc_ServiceInterface_CM']/@subContainerMappings[name='Cc_Operation_CM']/@subNodeMappings[name='Cc_In_Param']/@style"/>
+              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_0r07s1I4EeOAbOpuPpv3gw"/>
+              <color xmi:type="viewpoint:RGBValues" xmi:id="_0r07tFI4EeOAbOpuPpv3gw" red="136" green="136" blue="136"/>
+            </ownedStyle>
+            <actualMapping xmi:type="description:NodeMapping" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='Component%20Contract%20Diagram']/@defaultLayer/@containerMappings[name='Cc_ServiceInterface_CM']/@subContainerMappings[name='Cc_Operation_CM']/@subNodeMappings[name='Cc_In_Param']"/>
+          </ownedElements>
+        </ownedDiagramElements>
+      </ownedDiagramElements>
+      <description xmi:type="description:DiagramDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='Component%20Contract%20Diagram']"/>
+      <filterVariableHistory xmi:type="viewpoint:FilterVariableHistory" xmi:id="_Klo9EVI4EeOAbOpuPpv3gw"/>
+      <activatedLayers xmi:type="description:Layer" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']/@ownedRepresentations[name='Component%20Contract%20Diagram']/@defaultLayer"/>
+      <target xmi:type="org.obeonetwork.dsl.soa:Component" href="My.ois#_VBV8YFI3EeOAbOpuPpv3gw"/>
+    </ownedRepresentations>
+    <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='SOA%20Views']"/>
+  </ownedViews>
+  <ownedViews xmi:type="viewpoint:DRepresentationContainer" xmi:id="_iFVCAFI1EeOAbOpuPpv3gw" initialized="true">
+    <ownedRepresentations xmi:type="viewpoint:DSemanticDiagram" xmi:id="_1vPycFI2EeOAbOpuPpv3gw" name="my Overview Diagram">
+      <ownedAnnotationEntries xmi:type="description:AnnotationEntry" xmi:id="_1wl2QFI2EeOAbOpuPpv3gw" source="GMF_DIAGRAMS">
+        <data xmi:type="notation:Diagram" xmi:id="_1wl2QVI2EeOAbOpuPpv3gw" type="Viewpoint" element="_1vPycFI2EeOAbOpuPpv3gw" measurementUnit="Pixel">
+          <children xmi:type="notation:Node" xmi:id="_2DbSsFI2EeOAbOpuPpv3gw" type="2001" element="_2CCyoFI2EeOAbOpuPpv3gw">
+            <children xmi:type="notation:Node" xmi:id="_2DfkIFI2EeOAbOpuPpv3gw" type="5002">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_2DfkIVI2EeOAbOpuPpv3gw" y="-21"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_2D2JcFI2EeOAbOpuPpv3gw" type="3004" element="_2CQOAFI2EeOAbOpuPpv3gw">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_2D2JcVI2EeOAbOpuPpv3gw" fontName="Sans"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2D2JclI2EeOAbOpuPpv3gw"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_2DbSsVI2EeOAbOpuPpv3gw" fontName="Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2DbSslI2EeOAbOpuPpv3gw" x="75" y="35" width="50" height="50"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_2Dx4AFI2EeOAbOpuPpv3gw" type="2001" element="_2CSDMFI2EeOAbOpuPpv3gw">
+            <children xmi:type="notation:Node" xmi:id="_2DyfEFI2EeOAbOpuPpv3gw" type="5002">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_2DyfEVI2EeOAbOpuPpv3gw" y="-21"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_2D3XkFI2EeOAbOpuPpv3gw" type="3004" element="_2CvWMFI2EeOAbOpuPpv3gw">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_2D3XkVI2EeOAbOpuPpv3gw" fontName="Sans"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2D3XklI2EeOAbOpuPpv3gw"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_2Dx4AVI2EeOAbOpuPpv3gw" fontName="Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2Dx4AlI2EeOAbOpuPpv3gw" x="195" y="35" width="50" height="50"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_2DzGIFI2EeOAbOpuPpv3gw" type="2001" element="_2CvWNFI2EeOAbOpuPpv3gw">
+            <children xmi:type="notation:Node" xmi:id="_2D0UQFI2EeOAbOpuPpv3gw" type="5002">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_2D0UQVI2EeOAbOpuPpv3gw" y="-21"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_2D4lsFI2EeOAbOpuPpv3gw" type="3004" element="_2DQTkFI2EeOAbOpuPpv3gw">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_2D4lsVI2EeOAbOpuPpv3gw" fontName="Sans"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2D4lslI2EeOAbOpuPpv3gw"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_2DzGIVI2EeOAbOpuPpv3gw" fontName="Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_2DzGIlI2EeOAbOpuPpv3gw" x="325" y="35" width="50" height="50"/>
+          </children>
+          <styles xmi:type="notation:DiagramStyle" xmi:id="_1wl2QlI2EeOAbOpuPpv3gw"/>
+        </data>
+      </ownedAnnotationEntries>
+      <ownedDiagramElements xmi:type="viewpoint:DNode" xmi:id="_2CCyoFI2EeOAbOpuPpv3gw" name="Entity" width="5" height="5">
+        <target xmi:type="oent:Root" href="My.ois#_gjSAcVI1EeOAbOpuPpv3gw"/>
+        <semanticElements xmi:type="oent:Root" href="My.ois#_gjSAcVI1EeOAbOpuPpv3gw"/>
+        <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+        <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+        <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+        <ownedStyle xmi:type="viewpoint:BundledImage" xmi:id="_2CQOAFI2EeOAbOpuPpv3gw">
+          <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_2CQOAVI2EeOAbOpuPpv3gw"/>
+          <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='IS%20Views']/@ownedRepresentations[name='Overview%20Diagram']/@defaultLayer/@nodeMappings[name='RootEObject']/@conditionnalStyles.1/@style"/>
+          <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_2CQOAlI2EeOAbOpuPpv3gw" red="252" green="175" blue="62"/>
+          <color xmi:type="viewpoint:RGBValues" xmi:id="_2CQOA1I2EeOAbOpuPpv3gw" red="253" green="206" blue="137"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description:NodeMapping" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='IS%20Views']/@ownedRepresentations[name='Overview%20Diagram']/@defaultLayer/@nodeMappings[name='RootEObject']"/>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="viewpoint:DNode" xmi:id="_2CSDMFI2EeOAbOpuPpv3gw" name="SOA" width="5" height="5">
+        <target xmi:type="org.obeonetwork.dsl.soa:System" href="My.ois#_gjSngFI1EeOAbOpuPpv3gw"/>
+        <semanticElements xmi:type="org.obeonetwork.dsl.soa:System" href="My.ois#_gjSngFI1EeOAbOpuPpv3gw"/>
+        <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+        <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+        <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+        <ownedStyle xmi:type="viewpoint:BundledImage" xmi:id="_2CvWMFI2EeOAbOpuPpv3gw">
+          <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_2CvWMVI2EeOAbOpuPpv3gw"/>
+          <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='IS%20Views']/@ownedRepresentations[name='Overview%20Diagram']/@defaultLayer/@nodeMappings[name='RootEObject']/@conditionnalStyles.0/@style"/>
+          <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_2CvWMlI2EeOAbOpuPpv3gw" red="114" green="159" blue="207"/>
+          <color xmi:type="viewpoint:RGBValues" xmi:id="_2CvWM1I2EeOAbOpuPpv3gw" red="194" green="239" blue="255"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description:NodeMapping" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='IS%20Views']/@ownedRepresentations[name='Overview%20Diagram']/@defaultLayer/@nodeMappings[name='RootEObject']"/>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="viewpoint:DNode" xmi:id="_2CvWNFI2EeOAbOpuPpv3gw" name="Cinematic" width="5" height="5">
+        <target xmi:type="cinematic:CinematicRoot" href="My.ois#_gjSngVI1EeOAbOpuPpv3gw"/>
+        <semanticElements xmi:type="cinematic:CinematicRoot" href="My.ois#_gjSngVI1EeOAbOpuPpv3gw"/>
+        <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+        <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+        <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+        <ownedStyle xmi:type="viewpoint:BundledImage" xmi:id="_2DQTkFI2EeOAbOpuPpv3gw">
+          <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_2DQTkVI2EeOAbOpuPpv3gw"/>
+          <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='IS%20Views']/@ownedRepresentations[name='Overview%20Diagram']/@defaultLayer/@nodeMappings[name='RootEObject']/@conditionnalStyles.2/@style"/>
+          <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_2DQTklI2EeOAbOpuPpv3gw" red="173" green="127" blue="168"/>
+          <color xmi:type="viewpoint:RGBValues" xmi:id="_2DQTk1I2EeOAbOpuPpv3gw" red="217" green="196" blue="215"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description:NodeMapping" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='IS%20Views']/@ownedRepresentations[name='Overview%20Diagram']/@defaultLayer/@nodeMappings[name='RootEObject']"/>
+      </ownedDiagramElements>
+      <description xmi:type="description:DiagramDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='IS%20Views']/@ownedRepresentations[name='Overview%20Diagram']"/>
+      <filterVariableHistory xmi:type="viewpoint:FilterVariableHistory" xmi:id="_1vQZgFI2EeOAbOpuPpv3gw"/>
+      <activatedLayers xmi:type="description:Layer" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='IS%20Views']/@ownedRepresentations[name='Overview%20Diagram']/@defaultLayer"/>
+      <target xmi:type="overview:Root" href="My.ois#_gjSAcFI1EeOAbOpuPpv3gw"/>
+    </ownedRepresentations>
+    <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='IS%20Views']"/>
+  </ownedViews>
+  <ownedViews xmi:type="viewpoint:DRepresentationContainer" xmi:id="_iFc90FI1EeOAbOpuPpv3gw" initialized="true">
+    <ownedRepresentations xmi:type="viewpoint:DSemanticDiagram" xmi:id="_55iooFI2EeOAbOpuPpv3gw" name="Block Hierarchy Diagram">
+      <ownedAnnotationEntries xmi:type="description:AnnotationEntry" xmi:id="_55u14FI2EeOAbOpuPpv3gw" source="GMF_DIAGRAMS">
+        <data xmi:type="notation:Diagram" xmi:id="_55u14VI2EeOAbOpuPpv3gw" type="Viewpoint" element="_55iooFI2EeOAbOpuPpv3gw" measurementUnit="Pixel">
+          <children xmi:type="notation:Node" xmi:id="_56iuMFI2EeOAbOpuPpv3gw" type="2001" element="_56cnkFI2EeOAbOpuPpv3gw">
+            <children xmi:type="notation:Node" xmi:id="_56jVQFI2EeOAbOpuPpv3gw" type="5002">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_56jVQVI2EeOAbOpuPpv3gw" y="-21"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_56kjYFI2EeOAbOpuPpv3gw" type="3004" element="_56d1sFI2EeOAbOpuPpv3gw">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_56kjYVI2EeOAbOpuPpv3gw" fontName="Sans"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_56kjYlI2EeOAbOpuPpv3gw"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_56iuMVI2EeOAbOpuPpv3gw" fontName="Sans" fontHeight="8"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_56iuMlI2EeOAbOpuPpv3gw" x="145" y="45" width="50" height="50"/>
+          </children>
+          <styles xmi:type="notation:DiagramStyle" xmi:id="_55u14lI2EeOAbOpuPpv3gw"/>
+        </data>
+      </ownedAnnotationEntries>
+      <ownedDiagramElements xmi:type="viewpoint:DNode" xmi:id="_56cnkFI2EeOAbOpuPpv3gw" name="Block_1" width="5" height="5">
+        <target xmi:type="oent:Block" href="My.ois#_QZk8gFI2EeOAbOpuPpv3gw"/>
+        <semanticElements xmi:type="oent:Block" href="My.ois#_QZk8gFI2EeOAbOpuPpv3gw"/>
+        <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+        <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+        <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+        <ownedStyle xmi:type="viewpoint:BundledImage" xmi:id="_56d1sFI2EeOAbOpuPpv3gw" labelAlignment="LEFT">
+          <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_56d1sVI2EeOAbOpuPpv3gw"/>
+          <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='Entity%20Views']/@ownedRepresentations[name='Block%20Hierarchy%20Diagram']/@defaultLayer/@nodeMappings[name='BHD_Block']/@conditionnalStyles.0/@style"/>
+          <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_56d1slI2EeOAbOpuPpv3gw"/>
+          <color xmi:type="viewpoint:RGBValues" xmi:id="_56d1s1I2EeOAbOpuPpv3gw" red="204" green="242" blue="166"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description:NodeMapping" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='Entity%20Views']/@ownedRepresentations[name='Block%20Hierarchy%20Diagram']/@defaultLayer/@nodeMappings[name='BHD_Block']"/>
+      </ownedDiagramElements>
+      <description xmi:type="description:DiagramDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='Entity%20Views']/@ownedRepresentations[name='Block%20Hierarchy%20Diagram']"/>
+      <filterVariableHistory xmi:type="viewpoint:FilterVariableHistory" xmi:id="_55jPsFI2EeOAbOpuPpv3gw"/>
+      <activatedLayers xmi:type="description:Layer" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='Entity%20Views']/@ownedRepresentations[name='Block%20Hierarchy%20Diagram']/@defaultLayer"/>
+      <target xmi:type="oent:Root" href="My.ois#_gjSAcVI1EeOAbOpuPpv3gw"/>
+    </ownedRepresentations>
+    <ownedRepresentations xmi:type="viewpoint:DSemanticDiagram" xmi:id="_6xPFoFI2EeOAbOpuPpv3gw" name="Block_1 Entity Diagram">
+      <ownedAnnotationEntries xmi:type="description:AnnotationEntry" xmi:id="_6xXogFI2EeOAbOpuPpv3gw" source="GMF_DIAGRAMS">
+        <data xmi:type="notation:Diagram" xmi:id="_6xYPkFI2EeOAbOpuPpv3gw" type="Viewpoint" element="_6xPFoFI2EeOAbOpuPpv3gw" measurementUnit="Pixel">
+          <children xmi:type="notation:Node" xmi:id="_6yx9wFI2EeOAbOpuPpv3gw" type="2002" element="_6yRncFI2EeOAbOpuPpv3gw">
+            <children xmi:type="notation:Node" xmi:id="_6y0aAFI2EeOAbOpuPpv3gw" type="5006"/>
+            <children xmi:type="notation:Node" xmi:id="_6y22QFI2EeOAbOpuPpv3gw" type="7001">
+              <children xmi:type="notation:Node" xmi:id="_6y4EYFI2EeOAbOpuPpv3gw" type="3009" element="_6yfC0FI2EeOAbOpuPpv3gw">
+                <children xmi:type="notation:Node" xmi:id="_6y55kFI2EeOAbOpuPpv3gw" type="5004"/>
+                <children xmi:type="notation:Node" xmi:id="_6y7HsFI2EeOAbOpuPpv3gw" type="7003">
+                  <children xmi:type="notation:Node" xmi:id="_6y8V0FI2EeOAbOpuPpv3gw" type="3010" element="_6yjUQFI2EeOAbOpuPpv3gw">
+                    <layoutConstraint xmi:type="notation:Location" xmi:id="_6y8V0VI2EeOAbOpuPpv3gw"/>
+                  </children>
+                  <children xmi:type="notation:Node" xmi:id="_6y9j8FI2EeOAbOpuPpv3gw" type="3010" element="_6ym-oFI2EeOAbOpuPpv3gw">
+                    <layoutConstraint xmi:type="notation:Location" xmi:id="_6y9j8VI2EeOAbOpuPpv3gw"/>
+                  </children>
+                  <styles xmi:type="notation:SortingStyle" xmi:id="_6y7HsVI2EeOAbOpuPpv3gw"/>
+                  <styles xmi:type="notation:FilteringStyle" xmi:id="_6y7HslI2EeOAbOpuPpv3gw"/>
+                </children>
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_6y4EYVI2EeOAbOpuPpv3gw" fontName="Sans" fontHeight="10"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6y4EYlI2EeOAbOpuPpv3gw" x="40" y="49" width="218" height="83"/>
+              </children>
+              <styles xmi:type="notation:SortingStyle" xmi:id="_6y22QVI2EeOAbOpuPpv3gw"/>
+              <styles xmi:type="notation:FilteringStyle" xmi:id="_6y22QlI2EeOAbOpuPpv3gw"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_6yx9wVI2EeOAbOpuPpv3gw" fontName="Sans" fontHeight="10" bold="true"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6yx9wlI2EeOAbOpuPpv3gw" x="60" y="20" width="313" height="158"/>
+          </children>
+          <styles xmi:type="notation:DiagramStyle" xmi:id="_6xYPkVI2EeOAbOpuPpv3gw"/>
+        </data>
+      </ownedAnnotationEntries>
+      <ownedDiagramElements xmi:type="viewpoint:DNodeContainer" xmi:id="_6yRncFI2EeOAbOpuPpv3gw" name="Block_1">
+        <target xmi:type="oent:Block" href="My.ois#_QZk8gFI2EeOAbOpuPpv3gw"/>
+        <semanticElements xmi:type="oent:Block" href="My.ois#_QZk8gFI2EeOAbOpuPpv3gw"/>
+        <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+        <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+        <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+        <ownedStyle xmi:type="viewpoint:FlatContainerStyle" xmi:id="_6yVR0FI2EeOAbOpuPpv3gw" labelSize="10" labelFormat="bold">
+          <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_6yVR0VI2EeOAbOpuPpv3gw"/>
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='Entity%20Views']/@ownedRepresentations[name='Entity%20Diagram']/@defaultLayer/@containerMappings[name='ED_Block_Container']/@style"/>
+          <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_6yVR0lI2EeOAbOpuPpv3gw" red="255" green="245" blue="181"/>
+          <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_6yVR01I2EeOAbOpuPpv3gw" red="255" green="255" blue="255"/>
+          <foregroundColor xmi:type="viewpoint:RGBValues" xmi:id="_6yVR1FI2EeOAbOpuPpv3gw" red="255" green="245" blue="181"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description:ContainerMapping" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='Entity%20Views']/@ownedRepresentations[name='Entity%20Diagram']/@defaultLayer/@containerMappings[name='ED_Block_Container']"/>
+        <ownedDiagramElements xmi:type="viewpoint:DNodeList" xmi:id="_6yfC0FI2EeOAbOpuPpv3gw" name="Entity_1">
+          <target xmi:type="oent:Entity" href="My.ois#_SfuwsFI2EeOAbOpuPpv3gw"/>
+          <semanticElements xmi:type="oent:Entity" href="My.ois#_SfuwsFI2EeOAbOpuPpv3gw"/>
+          <decorations xmi:type="viewpoint:Decoration" xmi:id="_6yqB8FI2EeOAbOpuPpv3gw">
+            <description xmi:type="description:MappingBasedDecoration" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='Entity%20Views']/@ownedRepresentations[name='Entity%20Diagram']/@defaultLayer/@decorationDescriptionsSet/@decorationDescriptions[name='Entity%20Mapping%20Subclass']"/>
+          </decorations>
+          <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+          <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+          <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+          <ownedStyle xmi:type="viewpoint:FlatContainerStyle" xmi:id="_6yfp4FI2EeOAbOpuPpv3gw" labelSize="10" backgroundStyle="GradientTopToBottom">
+            <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_6yfp4VI2EeOAbOpuPpv3gw"/>
+            <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='Entity%20Views']/@ownedRepresentations[name='Entity%20Diagram']/@defaultLayer/@containerMappings[name='ED_Block_Container']/@subContainerMappings[name='ED_Entity']/@style"/>
+            <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_6yfp4lI2EeOAbOpuPpv3gw" red="138" green="226" blue="52"/>
+            <backgroundColor xmi:type="viewpoint:RGBValues" xmi:id="_6yfp41I2EeOAbOpuPpv3gw" red="204" green="242" blue="166"/>
+            <foregroundColor xmi:type="viewpoint:RGBValues" xmi:id="_6yfp5FI2EeOAbOpuPpv3gw" red="255" green="255" blue="255"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description:ContainerMapping" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='Entity%20Views']/@ownedRepresentations[name='Entity%20Diagram']/@defaultLayer/@containerMappings[name='ED_Block_Container']/@subContainerMappings[name='ED_Entity']"/>
+          <ownedElements xmi:type="viewpoint:DNodeListElement" xmi:id="_6yjUQFI2EeOAbOpuPpv3gw" name="attribute1 : String[0..1]">
+            <target xmi:type="oent:Attribute" href="My.ois#_kEVP4FI2EeOAbOpuPpv3gw"/>
+            <semanticElements xmi:type="oent:Attribute" href="My.ois#_kEVP4FI2EeOAbOpuPpv3gw"/>
+            <ownedStyle xmi:type="viewpoint:Square" xmi:id="_6ylJcFI2EeOAbOpuPpv3gw" labelAlignment="LEFT">
+              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_6ylwgFI2EeOAbOpuPpv3gw"/>
+              <description xmi:type="style:SquareDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='Entity%20Views']/@ownedRepresentations[name='Entity%20Diagram']/@defaultLayer/@containerMappings[name='ED_Block_Container']/@subContainerMappings[name='ED_Entity']/@subNodeMappings[name='ED_Attribute']/@style"/>
+              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_6ylwgVI2EeOAbOpuPpv3gw"/>
+              <color xmi:type="viewpoint:RGBValues" xmi:id="_6ylwglI2EeOAbOpuPpv3gw" red="136" green="136" blue="136"/>
+            </ownedStyle>
+            <actualMapping xmi:type="description:NodeMapping" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='Entity%20Views']/@ownedRepresentations[name='Entity%20Diagram']/@defaultLayer/@containerMappings[name='ED_Block_Container']/@subContainerMappings[name='ED_Entity']/@subNodeMappings[name='ED_Attribute']"/>
+          </ownedElements>
+          <ownedElements xmi:type="viewpoint:DNodeListElement" xmi:id="_6ym-oFI2EeOAbOpuPpv3gw" name="attribute2 : Integer[1]">
+            <target xmi:type="oent:Attribute" href="My.ois#_qRfVsFI2EeOAbOpuPpv3gw"/>
+            <semanticElements xmi:type="oent:Attribute" href="My.ois#_qRfVsFI2EeOAbOpuPpv3gw"/>
+            <ownedStyle xmi:type="viewpoint:Square" xmi:id="_6yoMwFI2EeOAbOpuPpv3gw" labelAlignment="LEFT">
+              <labelColor xmi:type="viewpoint:RGBValues" xmi:id="_6yoMwVI2EeOAbOpuPpv3gw"/>
+              <description xmi:type="style:SquareDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='Entity%20Views']/@ownedRepresentations[name='Entity%20Diagram']/@defaultLayer/@containerMappings[name='ED_Block_Container']/@subContainerMappings[name='ED_Entity']/@subNodeMappings[name='ED_Attribute']/@style"/>
+              <borderColor xmi:type="viewpoint:RGBValues" xmi:id="_6yoMwlI2EeOAbOpuPpv3gw"/>
+              <color xmi:type="viewpoint:RGBValues" xmi:id="_6yoMw1I2EeOAbOpuPpv3gw" red="136" green="136" blue="136"/>
+            </ownedStyle>
+            <actualMapping xmi:type="description:NodeMapping" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='Entity%20Views']/@ownedRepresentations[name='Entity%20Diagram']/@defaultLayer/@containerMappings[name='ED_Block_Container']/@subContainerMappings[name='ED_Entity']/@subNodeMappings[name='ED_Attribute']"/>
+          </ownedElements>
+        </ownedDiagramElements>
+      </ownedDiagramElements>
+      <description xmi:type="description:DiagramDescription" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='Entity%20Views']/@ownedRepresentations[name='Entity%20Diagram']"/>
+      <filterVariableHistory xmi:type="viewpoint:FilterVariableHistory" xmi:id="_6xPFoVI2EeOAbOpuPpv3gw"/>
+      <activatedLayers xmi:type="description:Layer" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='Entity%20Views']/@ownedRepresentations[name='Entity%20Diagram']/@defaultLayer"/>
+      <target xmi:type="oent:Block" href="My.ois#_QZk8gFI2EeOAbOpuPpv3gw"/>
+    </ownedRepresentations>
+    <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.obeonetwork.dsl.is.design/description/is.odesign#//@ownedViewpoints[name='Entity%20Views']"/>
+  </ownedViews>
+</viewpoint:DAnalysis>

--- a/releng/org.obeonetwork.informationsystem.build/generators/pom.xml
+++ b/releng/org.obeonetwork.informationsystem.build/generators/pom.xml
@@ -131,6 +131,14 @@
 		-->
 		<module>../../../generators/web/plugins/org.obeonetwork.informationsystem.gen.web</module>	
 		<module>../../../generators/web/features/org.obeonetwork.informationsystem.gen.web.feature</module>
+    
+      <!-- 
+      *********************************************************************************************
+      * SOA Generator Modules
+      *********************************************************************************************
+      -->
+      <module>../../../generators/soa/plugins/org.obeonetwork.dsl.soa.gen.contracts</module>   
+      <module>../../../generators/soa/features/org.obeonetwork.dsl.soa.gen.contracts.feature</module>
 		
 		<!-- 
 		*********************************************************************************************

--- a/releng/org.obeonetwork.informationsystem.generators.repository/category.xml
+++ b/releng/org.obeonetwork.informationsystem.generators.repository/category.xml
@@ -18,6 +18,9 @@
    <feature url="features/org.obeonetwork.dsl.soa.gen.java.spring.hibernate.feature_2.3.0.qualifier.jar" id="org.obeonetwork.dsl.soa.gen.java.spring.hibernate.feature" version="2.3.0.qualifier">
       <category name="org.obeonetwork.informationsystem.generators"/>
    </feature>
+   <feature url="features/org.obeonetwork.dsl.soa.gen.contracts.feature_2.3.0.qualifier.jar" id="org.obeonetwork.dsl.soa.gen.contracts.feature" version="2.3.0.qualifier">
+      <category name="org.obeonetwork.informationsystem.generators"/>
+   </feature>
    <feature url="features/org.obeonetwork.acceleo.feature_2.3.0.qualifier.jar" id="org.obeonetwork.acceleo.feature" version="2.3.0.qualifier">
       <category name="org.obeonetwork.informationsystem.generators"/>
    </feature>


### PR DESCRIPTION
Hello,

This commit adds generators for SOA DSL that provides XSD grammars and services WSDL contracts from an InformationSystem model. First part of this contribution was developped earlier and explained here http://lbroudoux.wordpress.com/2013/02/12/generating-soa-contracts-with-obeo-soadesigner/. It has now been extended with support for fault elements within services and support for basic type restrictions into XSD. 

The generators specifications are the following :
* generate 1 XSD artifact per Category or sub-Category holding DTOs,
* use the parent system name, category name and version to produce distinct file name,
* generate 1 WSDL artifact per Service holding Operations,
* make the WSDL artifact hold only the service related datatypes and reference reusable one from XSD,
* use the service name and version to produce distinct file name

The currently supported features of generators are as followed :
* usage of descriptions put into models to annotate artifacts with documentation,
* usage of multiplicity informations to generate according XSD occurence specifications,
* correct import of XSD within another XSD or a WSDL,
* correct usages of different namespaces during inclusions and reuse,
* support of inheritance between DTOs,
* support of composition and references between DTOs,
* support of constrained types when DTOs contain Annotation Metadata that specifiy them.

A test project with model and sample generation results is provided.

Let me know if it helps or if some more work need to be done in order of proper intergration.

Best regards,

Laurent

