### PR TITLE
Avoid potential NullPointerException

### DIFF
--- a/m2doc/database/plugins/org.obeonetwork.database.m2doc.services/src/org/obeonetwork/database/m2doc/services/ColumnServices.java
+++ b/m2doc/database/plugins/org.obeonetwork.database.m2doc.services/src/org/obeonetwork/database/m2doc/services/ColumnServices.java
@@ -244,7 +244,11 @@ public class ColumnServices {
             TypeInstance instance = (TypeInstance) type;
             switch (instance.getNativeType().getSpec()) {
                 case LENGTH:
-                    res = instance.getLength().toString();
+                    if (instance.getLength() == null) {
+                        res = "";
+                    } else {
+                        res = instance.getLength().toString();
+                    }
                     break;
                 case LENGTH_AND_PRECISION:
                     res = instance.getLength() + "," + instance.getPrecision();


### PR DESCRIPTION
Avoid potential NullPointerException when a TypeInstance doesn't have a
length.