### PR TITLE
[SAFRAN-1064]Restore opposite Reference upon library update

### DIFF
--- a/commons/tools/plugins/org.obeonetwork.tools.projectlibrary/META-INF/MANIFEST.MF
+++ b/commons/tools/plugins/org.obeonetwork.tools.projectlibrary/META-INF/MANIFEST.MF
@@ -18,7 +18,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.ui.ide,
  org.eclipse.sirius.ecore.extender,
  org.eclipse.sirius.common,
- org.obeonetwork.utils.common
+ org.obeonetwork.utils.common,
+ org.obeonetwork.dsl.environment
 Eclipse-LazyStart: true
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy

--- a/commons/tools/plugins/org.obeonetwork.tools.projectlibrary/src/org/obeonetwork/tools/projectlibrary/util/EReferenceReferenceReferencedTypeToRestoreWithOpposite.java
+++ b/commons/tools/plugins/org.obeonetwork.tools.projectlibrary/src/org/obeonetwork/tools/projectlibrary/util/EReferenceReferenceReferencedTypeToRestoreWithOpposite.java
@@ -1,0 +1,22 @@
+package org.obeonetwork.tools.projectlibrary.util;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.obeonetwork.dsl.environment.Reference;
+
+public class EReferenceReferenceReferencedTypeToRestoreWithOpposite extends ToBeRestoredReference {
+
+	protected final Reference oppositeReference;
+
+	public EReferenceReferenceReferencedTypeToRestoreWithOpposite(EObject sourceObject,
+			EStructuralFeature referencingFeature, String targetKey, Integer position, boolean canBeRestored,
+			final Reference oppositeReference) {
+		super(sourceObject, referencingFeature, targetKey, position, canBeRestored);
+		this.oppositeReference = oppositeReference;
+	}
+	
+	public Reference getOppositeReference() {
+		return oppositeReference;
+	}
+
+}

--- a/commons/tools/plugins/org.obeonetwork.tools.projectlibrary/src/org/obeonetwork/tools/projectlibrary/util/ProjectLibraryUtils.java
+++ b/commons/tools/plugins/org.obeonetwork.tools.projectlibrary/src/org/obeonetwork/tools/projectlibrary/util/ProjectLibraryUtils.java
@@ -27,11 +27,13 @@ import org.eclipse.core.runtime.Path;
 import org.eclipse.emf.common.util.TreeIterator;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.EStructuralFeature.Setting;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.util.ECrossReferenceAdapter;
+import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.transaction.RecordingCommand;
 import org.eclipse.emf.transaction.TransactionalEditingDomain;
 import org.eclipse.sirius.business.api.modelingproject.ModelingProject;
@@ -39,6 +41,9 @@ import org.eclipse.sirius.business.api.session.Session;
 import org.eclipse.sirius.business.api.session.SessionManager;
 import org.eclipse.sirius.ext.base.Option;
 import org.eclipse.sirius.viewpoint.ViewpointPackage;
+import org.obeonetwork.dsl.environment.EnvironmentPackage;
+import org.obeonetwork.dsl.environment.Reference;
+import org.obeonetwork.dsl.environment.StructuredType;
 import org.obeonetwork.dsl.manifest.MManifest;
 import org.obeonetwork.tools.projectlibrary.extension.ManifestServices;
 import org.obeonetwork.tools.projectlibrary.extension.point.AbstractImportHandler;
@@ -49,23 +54,70 @@ import org.obeonetwork.utils.common.SessionUtils;
 
 /**
  * Utilities around Project libraries
+ * 
  * @author <a href="mailto:stephane.thibaudeau@obeo.fr">Stephane Thibaudeau</a>
  *
  */
 public class ProjectLibraryUtils {
-	
+
 	public void restoreReferences(Collection<ToBeRestoredReference> restorableReferences, Session targetSession) {
 		IdUtils idUtils = new IdUtils(targetSession);
-		
+
 		TransactionalEditingDomain ted = targetSession.getTransactionalEditingDomain();
-		
+
 		if (ted != null) {
 			for (ToBeRestoredReference restorableReference : restorableReferences) {
 				EObject targetObject = idUtils.getCorrespondingObject(restorableReference.getTargetKey());
 				EObject sourceObject = restorableReference.getSourceObject();
 				EStructuralFeature referencingFeature = restorableReference.getReferencingFeature();
-				
+
 				if (targetObject != null && referencingFeature.isChangeable()) {
+					// Prepare specific additional behavior in case we are about to restored an
+					// EReference that corresponds to environment::Reference.referencedType
+					final List<Runnable> commandPostBehaviors = new ArrayList<>();
+					if (restorableReference instanceof EReferenceReferenceReferencedTypeToRestoreWithOpposite) {
+						final EReferenceReferenceReferencedTypeToRestoreWithOpposite restorableReferenceReferencedType = (EReferenceReferenceReferencedTypeToRestoreWithOpposite) restorableReference;
+						final Reference source = (Reference) sourceObject;
+						final StructuredType target = (StructuredType) targetObject;
+						final Reference oppositeReferenceToRestore = restorableReferenceReferencedType
+								.getOppositeReference();
+						final Reference maybeAlreadyRestoredOppositeReference = (Reference) idUtils
+								.getCorrespondingObject(idUtils.getKey(oppositeReferenceToRestore));
+						final Reference restoredOppositeReference;
+						if (maybeAlreadyRestoredOppositeReference == null) {
+							final EcoreUtil.Copier copierWithoutCopyOfProxyUri = new EcoreUtil.Copier() {
+								private static final long serialVersionUID = 1L;
+
+								@Override
+								protected void copyProxyURI(EObject eObject, EObject copyEObject) {
+									// Suppress this copy because it breaks things, not sure why.
+									// Maybe the copied element still exists in the ResourceSet at this point.
+									// super.copyProxyURI(eObject, copyEObject);
+								}
+
+								@Override
+								protected void copyReference(EReference eReference, EObject eObject,
+										EObject copyEObject) {
+									super.copyReference(eReference, eObject, copyEObject);
+									// FIXME: won't we have issues with Reference.BindingRegistries or other
+									// non-containment EReferences that had their value located in the resource of
+									// the library?
+								}
+							};
+							restoredOppositeReference = (Reference) copierWithoutCopyOfProxyUri
+									.copy(oppositeReferenceToRestore);
+							commandPostBehaviors.add(() -> {
+								target.getOwnedReferences().add(restoredOppositeReference);
+							});
+						} else {
+							restoredOppositeReference = maybeAlreadyRestoredOppositeReference;
+						}
+						commandPostBehaviors.add(() -> {
+							restoredOppositeReference.setReferencedType((StructuredType) source.eContainer());
+							restoredOppositeReference.setOppositeOf(source);
+						});
+					}
+
 					RecordingCommand cmd = null;
 					if (referencingFeature.isMany() && restorableReference.getPosition() != null) {
 						// Multi valued feature
@@ -77,10 +129,11 @@ public class ProjectLibraryUtils {
 								Object eGet = sourceObject.eGet(referencingFeature);
 								if (eGet instanceof List) {
 									@SuppressWarnings("unchecked")
-									List<Object> list = (List<Object>)eGet;
+									List<Object> list = (List<Object>) eGet;
 									list.remove(position);
 									list.add(position, targetObject);
 								}
+								commandPostBehaviors.forEach(Runnable::run);
 							}
 						};
 					} else {
@@ -90,9 +143,11 @@ public class ProjectLibraryUtils {
 							@Override
 							protected void doExecute() {
 								sourceObject.eSet(referencingFeature, targetObject);
+								commandPostBehaviors.forEach(Runnable::run);
 							}
 						};
 					}
+
 					if (cmd != null) {
 						ted.getCommandStack().execute(cmd);
 					}
@@ -100,7 +155,7 @@ public class ProjectLibraryUtils {
 			}
 		}
 	}
-	
+
 	/**
 	 * 
 	 * @param project
@@ -109,53 +164,56 @@ public class ProjectLibraryUtils {
 	 * @param shouldDeleteResource
 	 * @return
 	 */
-	public boolean removeImportedProjectAndResources(IProject project, Collection<Resource> resourcesToDelete, MManifest projectToRemove, boolean shouldDeleteResource) throws LibraryImportException {
+	public boolean removeImportedProjectAndResources(IProject project, Collection<Resource> resourcesToDelete,
+			MManifest projectToRemove, boolean shouldDeleteResource) throws LibraryImportException {
 		Optional<Session> session = SessionUtils.getSession(project);
-		
+
 		boolean removed = false;
-		if(session.isPresent()) {
+		if (session.isPresent()) {
 			AbstractImportHandler importHandler = ImportHandlerFactory.getInstance().getImportHandler(session.get());
-			
-			if(importHandler instanceof DefaultImportHandler) {
-				removed = ((DefaultImportHandler)importHandler).removeImportedProjectAndResources(project, resourcesToDelete, projectToRemove, shouldDeleteResource);
-			}
-			else {
+
+			if (importHandler instanceof DefaultImportHandler) {
+				removed = ((DefaultImportHandler) importHandler).removeImportedProjectAndResources(project,
+						resourcesToDelete, projectToRemove, shouldDeleteResource);
+			} else {
 				removed = importHandler.removeImportedProjectAndResources(project, resourcesToDelete, projectToRemove);
 			}
-			
+
 			if (removed == true) {
 				// Remove the manifest from the imported manifests
 				new ManifestServices().removeImportedManifestFromSession(session.get(), projectToRemove);
 			}
 		}
-		
+
 		return removed;
 	}
-	
+
 	/**
 	 * Returns external references to objects in the collection of resources
+	 * 
 	 * @param session
 	 * @param resources
 	 * @return
 	 */
 	public Collection<Setting> getExternalReferences(Session session, Collection<Resource> resources) {
 		ECrossReferenceAdapter xReferencer = session.getSemanticCrossReferencer();
-		
-		Collection<Setting> externalReferences = new ArrayList<>(); 
-		
+
+		Collection<Setting> externalReferences = new ArrayList<>();
+
 		for (Resource resource : resources) {
 			TreeIterator<EObject> it = resource.getAllContents();
 			while (it.hasNext()) {
 				EObject object = it.next();
-				
+
 				Collection<Setting> inverseReferences = xReferencer.getInverseReferences(object);
-				
+
 				// Filter the references to keep only external references
 				// and ignore the mainAnalysis.getReferencedAnalysis() feature too
 				for (Setting setting : inverseReferences) {
 					if (!resources.contains(setting.getEObject().eResource())) {
-						if (!setting.getEStructuralFeature().equals(ViewpointPackage.Literals.DANALYSIS__REFERENCED_ANALYSIS)) {
-							externalReferences.add(setting);							
+						if (!setting.getEStructuralFeature()
+								.equals(ViewpointPackage.Literals.DANALYSIS__REFERENCED_ANALYSIS)) {
+							externalReferences.add(setting);
 						}
 					}
 				}
@@ -163,59 +221,73 @@ public class ProjectLibraryUtils {
 		}
 		return externalReferences;
 	}
-	
+
 	/**
 	 * Returns the external references that could not be restored after an import
+	 * 
 	 * @param externalReferences External references
-	 * @param deletedResources Resources that will be deleted
-	 * @param newSession New session
+	 * @param deletedResources   Resources that will be deleted
+	 * @param newSession         New session
 	 * @return
 	 */
-	public RestorableAndNonRestorableReferences getToBeRestoredReferences(Collection<Setting> externalReferences, Collection<Resource> deletedResources , Session newSession) {
+	public RestorableAndNonRestorableReferences getToBeRestoredReferences(Collection<Setting> externalReferences,
+			Collection<Resource> deletedResources, Session newSession) {
 		IdUtils idUtils = new IdUtils(newSession);
-		
+
 		RestorableAndNonRestorableReferences result = new RestorableAndNonRestorableReferences();
-		
+
 		for (Setting setting : externalReferences) {
-			// Each setting can reference objects to restore but also objects that will still be here
+			// Each setting can reference objects to restore but also objects that will
+			// still be here
 			// we check the containing resource to be sure
 			Object referencedObjects = setting.get(false);
 			ToBeRestoredReference restorableReference = null;
-			if (referencedObjects instanceof List)	{
-				for (Object referencedObject : (List<?>)referencedObjects) {
+			if (referencedObjects instanceof List) {
+				for (Object referencedObject : (List<?>) referencedObjects) {
 					if (referencedObject instanceof EObject) {
-						restorableReference = getRestorableReference(setting, (EObject)referencedObject, deletedResources, idUtils);
+						restorableReference = getRestorableReference(setting, (EObject) referencedObject,
+								deletedResources, idUtils);
 					}
 				}
 			} else if (referencedObjects instanceof EObject) {
-				restorableReference = getRestorableReference(setting, (EObject)referencedObjects, deletedResources, idUtils);
+				restorableReference = getRestorableReference(setting, (EObject) referencedObjects, deletedResources,
+						idUtils);
 			}
 			if (restorableReference != null) {
 				result.addReference(restorableReference);
 			}
 		}
-		
+
 		return result;
 	}
-	
-	private ToBeRestoredReference getRestorableReference(Setting setting, EObject referencedEObject, Collection<Resource> deletedResources, IdUtils idUtils) {
-		
+
+	private ToBeRestoredReference getRestorableReference(Setting setting, EObject referencedEObject,
+			Collection<Resource> deletedResources, IdUtils idUtils) {
+
 		if (deletedResources.contains(referencedEObject.eResource())) {
 			EStructuralFeature feature = setting.getEStructuralFeature();
-			String key = idUtils.getKey(referencedEObject);			
+			String key = idUtils.getKey(referencedEObject);
 			Integer position = null;
 			// if feature is multivalued we have to keep the position
 			if (feature.isMany()) {
 				Object value = setting.getEObject().eGet(feature);
 				if (value instanceof List) {
-					position = ((List<?>)value).indexOf(referencedEObject);
+					position = ((List<?>) value).indexOf(referencedEObject);
 				}
 			}
-			
+
 			// The referenced object will be removed
 			// lets see if we can restore it
 			if (idUtils.getCorrespondingObject(referencedEObject) != null) {
-				return new ToBeRestoredReference(setting.getEObject(), feature, key, position, true);
+				if (feature == EnvironmentPackage.Literals.REFERENCE__REFERENCED_TYPE) {
+					final Reference oppositeReference = ((Reference) setting.getEObject()).getOppositeOf();
+					if (oppositeReference != null && deletedResources.contains(oppositeReference.eResource())) {
+						return new EReferenceReferenceReferencedTypeToRestoreWithOpposite(setting.getEObject(), feature,
+								key, position, true, oppositeReference);
+					}
+				} else {
+					return new ToBeRestoredReference(setting.getEObject(), feature, key, position, true);
+				}
 			} else {
 				// non restorable reference
 				return new ToBeRestoredReference(setting.getEObject(), feature, key, position, false);
@@ -223,37 +295,41 @@ public class ProjectLibraryUtils {
 		}
 		return null;
 	}
-	
+
 	/**
 	 * Returns the list of resources corresponding to a previously imported project
+	 * 
 	 * @param modelingProject
 	 * @param projectToRemove
 	 * @return
 	 */
 	public Collection<Resource> getResourcesFromManifest(IProject modelingProject, MManifest projectToRemove) {
 		Optional<Session> session = SessionUtils.getSession(modelingProject);
-		if(session.isPresent()) {
+		if (session.isPresent()) {
 			AbstractImportHandler importHandler = ImportHandlerFactory.getInstance().getImportHandler(session.get());
 			return importHandler.getResourcesForImportedProject(modelingProject, projectToRemove);
 		}
-		
+
 		return new ArrayList<>();
 	}
-	
+
 	/**
-	 * Returns the list of resources corresponding to a previously imported project from the workspace.
+	 * Returns the list of resources corresponding to a previously imported project
+	 * from the workspace.
 	 * 
 	 * @param session
 	 * @param projectToRemove
 	 * @return
 	 */
 	public Collection<Resource> getResourcesFromWsManifest(Session session, MManifest projectToRemove) {
-		DefaultImportHandler importHandler = (DefaultImportHandler) ImportHandlerFactory.getInstance().getImportHandler(session);
+		DefaultImportHandler importHandler = (DefaultImportHandler) ImportHandlerFactory.getInstance()
+				.getImportHandler(session);
 		return importHandler.getResourcesForImportedWsProject(session, projectToRemove);
 	}
-	
+
 	/**
-	 * Return the list of projects containing a resource which is referenced by {@link modelingProject}.
+	 * Return the list of projects containing a resource which is referenced by
+	 * {@link modelingProject}.
 	 * 
 	 * @param modelingProject
 	 * @return the list of referenced projects
@@ -272,8 +348,9 @@ public class ProjectLibraryUtils {
 					if (optionWsModelingProject.some()) {
 						ModelingProject wsModelingProject = optionWsModelingProject.get();
 						Session session = wsModelingProject.getSession();
-						if(session == null) {
-							final Option<URI> optionalUri = wsModelingProject.getMainRepresentationsFileURI(new NullProgressMonitor());
+						if (session == null) {
+							final Option<URI> optionalUri = wsModelingProject
+									.getMainRepresentationsFileURI(new NullProgressMonitor());
 							session = SessionManager.INSTANCE.getSession(optionalUri.get(), new NullProgressMonitor());
 							session.open(new NullProgressMonitor());
 						}
@@ -284,7 +361,8 @@ public class ProjectLibraryUtils {
 									if (resource.getURI().isPlatform()) {
 										String uri = resource.getURI().toPlatformString(true);
 										Path resourcePath = new Path(uri);
-										IFile resourceFile = ResourcesPlugin.getWorkspace().getRoot().getFile(resourcePath);
+										IFile resourceFile = ResourcesPlugin.getWorkspace().getRoot()
+												.getFile(resourcePath);
 										IProject resourceProject = resourceFile.getProject();
 
 										if (resourceProject == modelingProject.getProject()) {
@@ -299,14 +377,13 @@ public class ProjectLibraryUtils {
 					}
 				}
 			}
-		}
-		catch (Exception e) {
+		} catch (Exception e) {
 			e.printStackTrace();
 		}
 
 		return result;
 	}
-	
+
 	/**
 	 * Return the list of projects referenced by {@link modelingProject}.
 	 * 
@@ -321,27 +398,28 @@ public class ProjectLibraryUtils {
 			List<IProject> workspaceProjects = Arrays.asList(projects);
 
 			Session session = modelingProject.getSession();
-			if(session == null) {
-				final Option<URI> optionalUri = modelingProject.getMainRepresentationsFileURI(new NullProgressMonitor());
+			if (session == null) {
+				final Option<URI> optionalUri = modelingProject
+						.getMainRepresentationsFileURI(new NullProgressMonitor());
 				session = SessionManager.INSTANCE.getSession(optionalUri.get(), new NullProgressMonitor());
 				session.open(new NullProgressMonitor());
 			}
-			
+
 			for (Resource res : session.getSemanticResources()) {
-				if(res.getURI().isPlatformResource() && !modelingProject.getProject().getName().equals(res.getURI().segment(1))) {
+				if (res.getURI().isPlatformResource()
+						&& !modelingProject.getProject().getName().equals(res.getURI().segment(1))) {
 					for (IProject wsProject : workspaceProjects) {
-						if(wsProject.getName().equals(res.getURI().segment(1))) {
+						if (wsProject.getName().equals(res.getURI().segment(1))) {
 							result.add(wsProject);
 						}
 					}
 				}
 			}
-		}
-		catch (Exception e) {
+		} catch (Exception e) {
 			e.printStackTrace();
 		}
 
 		return result;
 	}
-	
+
 }

--- a/commons/tools/plugins/org.obeonetwork.tools.projectlibrary/src/org/obeonetwork/tools/projectlibrary/util/ToBeRestoredReference.java
+++ b/commons/tools/plugins/org.obeonetwork.tools.projectlibrary/src/org/obeonetwork/tools/projectlibrary/util/ToBeRestoredReference.java
@@ -15,22 +15,24 @@ import org.eclipse.emf.ecore.EStructuralFeature;
 
 /**
  * Represents a reference to be restored
+ * 
  * @author <a href="mailto:stephane.thibaudeau@obeo.fr">Stephane Thibaudeau</a>
  *
  */
 public class ToBeRestoredReference {
 
 	private EObject sourceObject;
-	
+
 	private EStructuralFeature referencingFeature;
-	
+
 	private String targetKey;
-	
+
 	private Integer position;
-	
+
 	private boolean canBeRestored = false;
-	
-	public ToBeRestoredReference(EObject sourceObject, EStructuralFeature referencingFeature, String targetKey, Integer position, boolean canBeRestored) {
+
+	public ToBeRestoredReference(EObject sourceObject, EStructuralFeature referencingFeature, String targetKey,
+			Integer position, boolean canBeRestored) {
 		super();
 		this.sourceObject = sourceObject;
 		this.referencingFeature = referencingFeature;


### PR DESCRIPTION
Attempt to fix this issue by re-creating the opposite environment::Reference upon a library update.