### PR TITLE
SAFRAN-1080: Fix additional dependency ambiguities

### DIFF
--- a/addons/cinematic/plugins/org.obeonetwork.cinematic.gen.html/META-INF/MANIFEST.MF
+++ b/addons/cinematic/plugins/org.obeonetwork.cinematic.gen.html/META-INF/MANIFEST.MF
@@ -21,5 +21,4 @@ Eclipse-LazyStart: true
 Export-Package: org.obeonetwork.cinematic.gen.html.main,
  org.obeonetwork.cinematic.gen.html.services
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: com.google.common.collect;version="[21.0.0,27.2.0)"
 

--- a/designs/interaction/plugins/org.obeonetwork.dsl.interaction.design/META-INF/MANIFEST.MF
+++ b/designs/interaction/plugins/org.obeonetwork.dsl.interaction.design/META-INF/MANIFEST.MF
@@ -28,4 +28,3 @@ Require-Bundle: org.eclipse.ui,
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: Obeo Network
-Import-Package: com.google.common.collect;version="[21.0.0,27.2.0)"


### PR DESCRIPTION
This should fix the following sort of errors we now have due to having 2 Guava versions in the product, but some dependencies were not strict enough so Eclipse did not know which one to use.

```
org.osgi.framework.BundleException: Could not resolve module: org.obeonetwork.cinematic.gen.html [751]
  Bundle was not resolved because of a uses constraint violation.
  org.apache.felix.resolver.reason.ReasonException: Uses constraint violation. Unable to resolve resource org.obeonetwork.cinematic.gen.html [osgi.identity; osgi.identity="org.obeonetwork.cinematic.gen.html"; type="osgi.bundle"; version:Version="4.1.0.202307061320"] because it is exposed to package 'com.google.common.collect' from resources com.google.guava [osgi.identity; osgi.identity="com.google.guava"; type="osgi.bundle"; version:Version="21.0.0.v20170206-1425"] and com.google.guava [osgi.identity; osgi.identity="com.google.guava"; type="osgi.bundle"; version:Version="30.1.0.v20210127-2300"] via two dependency chains.

Chain 1:
  org.obeonetwork.cinematic.gen.html [osgi.identity; osgi.identity="org.obeonetwork.cinematic.gen.html"; type="osgi.bundle"; version:Version="4.1.0.202307061320"]
    import: (&(osgi.wiring.package=com.google.common.collect)(&(version>=21.0.0)(!(version>=27.2.0))))
     |
    export: osgi.wiring.package: com.google.common.collect
  com.google.guava [osgi.identity; osgi.identity="com.google.guava"; type="osgi.bundle"; version:Version="21.0.0.v20170206-1425"]

Chain 2:
  org.obeonetwork.cinematic.gen.html [osgi.identity; osgi.identity="org.obeonetwork.cinematic.gen.html"; type="osgi.bundle"; version:Version="4.1.0.202307061320"]
    require: (&(osgi.wiring.bundle=org.eclipse.acceleo.common)(bundle-version>=3.2.1))
     |
    provide: osgi.wiring.bundle; bundle-version:Version="3.7.12.202211151354"; osgi.wiring.bundle="org.eclipse.acceleo.common"; singleton:="true"
  org.eclipse.acceleo.common [osgi.identity; osgi.identity="org.eclipse.acceleo.common"; type="osgi.bundle"; version:Version="3.7.12.202211151354"; singleton:="true"]
    import: (&(osgi.wiring.package=com.google.common.collect)(&(version>=27.0.0)(!(version>=30.2.0))))
     |
    export: osgi.wiring.package: com.google.common.collect
  com.google.guava [osgi.identity; osgi.identity="com.google.guava"; type="osgi.bundle"; version:Version="30.1.0.v20210127-2300"]
```