### PR TITLE
[SAFRAN-1080]Use Mylyn 3.26.1 dedicated update site instead of Simrel

### DIFF
--- a/is-designer/releng/org.obeonetwork.is.designer.parent/target_platform/isdesigner.target
+++ b/is-designer/releng/org.obeonetwork.is.designer.parent/target_platform/isdesigner.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="IS Designer Product Target Definition" sequenceNumber="1688636607">
+<target name="IS Designer Product Target Definition" sequenceNumber="1688999933">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.core.runtime.feature.feature.group" version="0.0.0"/>
@@ -25,7 +25,7 @@
       <unit id="org.eclipse.mylyn.monitor.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.mylyn.tasks.ide.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.mylyn.team_feature.feature.group" version="0.0.0"/>
-      <repository id="Eclipse_Simrel-2023-06_Mylyn-3.26" location="http://download.eclipse.org/releases/2023-06/"/>
+      <repository id="Eclipse_Mylyn-3.26.1" location="https://download.eclipse.org/mylyn/updates/release/3.26.1/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="com.google.guava" version="0.0.0"/>
@@ -248,4 +248,5 @@
       <repository id="Polarion" location="https://community.polarion.com/projects/subversive/download/eclipse/6.0/update-site/"/>
     </location>
   </locations>
+  <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 </target>

--- a/is-designer/releng/org.obeonetwork.is.designer.parent/target_platform/isdesigner.tpd
+++ b/is-designer/releng/org.obeonetwork.is.designer.parent/target_platform/isdesigner.tpd
@@ -1,5 +1,7 @@
 target "IS Designer Product Target Definition" with source, requirements
 
+environment JavaSE-11
+
 location Eclipse "http://download.eclipse.org/releases/2021-06/" {
 	org.eclipse.core.runtime.feature.feature.group lazy
 	org.eclipse.ecf.core.feature.feature.group lazy
@@ -9,7 +11,7 @@ location Eclipse "http://download.eclipse.org/releases/2021-06/" {
 	com.sun.xml.bind lazy
 }
 
-location Eclipse_Simrel-2023-06_Mylyn-3.26 "http://download.eclipse.org/releases/2023-06/" {
+location Eclipse_Mylyn-3.26.1 "https://download.eclipse.org/mylyn/updates/release/3.26.1/" {
 	org.eclipse.mylyn_feature.feature.group lazy
 	org.eclipse.mylyn.bugzilla_feature.feature.group lazy
 	org.eclipse.mylyn.commons.feature.group lazy
@@ -141,19 +143,19 @@ location Obeo-Designer-Community "http://update.obeo.fr/release/designer/11.7/co
 	org.slf4j.api lazy
 	org.eclipse.emf.compare.rcp lazy
 	org.eclipse.emf.compare.rcp.ui lazy
-    org.eclipse.sirius.runtime.acceleo.feature.group lazy
-    org.eclipse.sirius.runtime.aql.feature.group lazy
-    org.eclipse.sirius.runtime.feature.group lazy
-    org.eclipse.sirius.runtime.ide.eef.feature.group lazy
-    org.eclipse.sirius.runtime.ide.ui.acceleo.feature.group lazy
-    org.eclipse.sirius.runtime.ide.ui.feature.group lazy
-    org.eclipse.sirius.runtime.ide.xtext.feature.group lazy
-    org.eclipse.sirius.runtime.ocl.feature.group lazy
-    org.eclipse.sirius.samples.feature.group lazy
-    org.eclipse.sirius.specifier.ide.ui.acceleo.feature.group lazy
-    org.eclipse.sirius.specifier.ide.ui.aql.feature.group lazy
-    org.eclipse.sirius.specifier.ide.ui.feature.group lazy
-    org.eclipse.sirius.tests.support.feature.group lazy
+	org.eclipse.sirius.runtime.acceleo.feature.group lazy
+	org.eclipse.sirius.runtime.aql.feature.group lazy
+	org.eclipse.sirius.runtime.feature.group lazy
+	org.eclipse.sirius.runtime.ide.eef.feature.group lazy
+	org.eclipse.sirius.runtime.ide.ui.acceleo.feature.group lazy
+	org.eclipse.sirius.runtime.ide.ui.feature.group lazy
+	org.eclipse.sirius.runtime.ide.xtext.feature.group lazy
+	org.eclipse.sirius.runtime.ocl.feature.group lazy
+	org.eclipse.sirius.samples.feature.group lazy
+	org.eclipse.sirius.specifier.ide.ui.acceleo.feature.group lazy
+	org.eclipse.sirius.specifier.ide.ui.aql.feature.group lazy
+	org.eclipse.sirius.specifier.ide.ui.feature.group lazy
+	org.eclipse.sirius.tests.support.feature.group lazy
 }
 
 location Obeo-Designer-Team "http://update.obeo.fr/release/designer/11.7/team/latest/repository/" {

--- a/releng/org.obeonetwork.informationsystem.parent/tp/isdesigner.target
+++ b/releng/org.obeonetwork.informationsystem.parent/tp/isdesigner.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="IS Designer Repository Target Definition" sequenceNumber="1688477576">
+<target name="IS Designer Repository Target Definition" sequenceNumber="1688999934">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="com.google.guava" version="0.0.0"/>
@@ -37,7 +37,7 @@
       <unit id="org.eclipse.mylyn.monitor.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.mylyn.tasks.ide.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.mylyn.team_feature.feature.group" version="0.0.0"/>
-      <repository id="Eclipse_Simrel-2023-06_Mylyn-3.26" location="http://download.eclipse.org/releases/2023-06/"/>
+      <repository id="Eclipse_Mylyn-3.26.1" location="https://download.eclipse.org/mylyn/updates/release/3.26.1/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="fr.obeo.dsl.viewpoint.collab.user.feature.group" version="0.0.0"/>

--- a/releng/org.obeonetwork.informationsystem.parent/tp/isdesigner.tpd
+++ b/releng/org.obeonetwork.informationsystem.parent/tp/isdesigner.tpd
@@ -21,7 +21,7 @@ location Obeo-Designer-Community "http://update.obeo.fr/release/designer/11.7/co
 	org.eclipse.sirius.tests.support.feature.group lazy
 }
 
-location Eclipse_Simrel-2023-06_Mylyn-3.26 "http://download.eclipse.org/releases/2023-06/" {
+location Eclipse_Mylyn-3.26.1 "https://download.eclipse.org/mylyn/updates/release/3.26.1/" {
 	org.eclipse.mylyn_feature.feature.group lazy
 	org.eclipse.mylyn.bugzilla_feature.feature.group lazy
 	org.eclipse.mylyn.commons.feature.group lazy


### PR DESCRIPTION
This should prevent other unbound dependencies from pulling newer versions of dependencies which require Java 17 and cause all sorts of mix-ups at runtime.